### PR TITLE
Add debugging information for user display

### DIFF
--- a/vidarr-cli/src/main/java/ca/on/oicr/gsi/vidarr/cli/SingleShotOperation.java
+++ b/vidarr-cli/src/main/java/ca/on/oicr/gsi/vidarr/cli/SingleShotOperation.java
@@ -16,6 +16,11 @@ final class SingleShotOperation implements ActiveOperation<Void> {
   }
 
   @Override
+  public void debugInfo(JsonNode info, Void transaction) {
+    // Throw this information away since we don't really want to log it
+  }
+
+  @Override
   public void log(System.Logger.Level level, String message) {
     singleShotWorkflow.log(level, message);
   }

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/ActiveOperation.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/ActiveOperation.java
@@ -9,6 +9,13 @@ import com.fasterxml.jackson.databind.JsonNode;
  */
 public interface ActiveOperation<TX> {
   /**
+   * Change the current client-visible debugging information
+   *
+   * @param info the debugging information to store
+   * @param transaction the transaction to perform the update in
+   */
+  void debugInfo(JsonNode info, TX transaction);
+  /**
    * Be told something something interesting
    *
    * @param level how important this message is

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseProcessor.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseProcessor.java
@@ -99,6 +99,15 @@ public abstract class BaseProcessor<
     }
 
     @Override
+    public void storeDebugInfo(JsonNode information) {
+      if (finished) {
+        throw new IllegalStateException(
+            "Operation is already complete. Cannot debugging information.");
+      }
+      startTransaction(transaction -> operation.debugInfo(information, transaction));
+    }
+
+    @Override
     public final synchronized void scheduleTask(long delay, TimeUnit units, Runnable task) {
       if (finished) {
         throw new IllegalStateException("Operation is already complete. Cannot schedule task.");

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/DelayWorkMonitor.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/DelayWorkMonitor.java
@@ -2,6 +2,7 @@ package ca.on.oicr.gsi.vidarr.core;
 
 import ca.on.oicr.gsi.vidarr.WorkMonitor;
 import ca.on.oicr.gsi.vidarr.WorkMonitor.Status;
+import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Deque;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.TimeUnit;
@@ -46,6 +47,11 @@ final class DelayWorkMonitor<T, S> implements WorkMonitor<T, S> {
 
   public void scheduleTask(long delay, TimeUnit units, Runnable task) {
     executeSafely(() -> delegate.scheduleTask(delay, units, task));
+  }
+
+  @Override
+  public void storeDebugInfo(JsonNode information) {
+    executeSafely(() -> delegate.storeDebugInfo(information));
   }
 
   public void scheduleTask(Runnable task) {

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/MonitorWithType.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/MonitorWithType.java
@@ -40,6 +40,11 @@ final class MonitorWithType<T> implements WorkMonitor<T, JsonNode> {
   }
 
   @Override
+  public void storeDebugInfo(JsonNode information) {
+    monitor.storeDebugInfo(information);
+  }
+
+  @Override
   public void scheduleTask(Runnable task) {
     monitor.scheduleTask(task);
   }

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/WrappedMonitor.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/WrappedMonitor.java
@@ -110,6 +110,11 @@ abstract class WrappedMonitor<A, R, S> implements WorkMonitor<R, JsonNode> {
   }
 
   @Override
+  public void storeDebugInfo(JsonNode information) {
+    monitor.storeDebugInfo(information);
+  }
+
+  @Override
   public final void storeRecoveryInformation(JsonNode state) {
     final var array = JsonNodeFactory.instance.arrayNode(2);
     array.insertPOJO(0, accessory);

--- a/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/CromwellCall.java
+++ b/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/CromwellCall.java
@@ -1,0 +1,99 @@
+package ca.on.oicr.gsi.vidarr.cromwell;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Collections;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CromwellCall {
+  private int attempt;
+  private String backend;
+  private String callRoot;
+  private String executionStatus;
+  private List<CromwellFailure> failures = Collections.emptyList();
+  private String jobId;
+  private Long returnCode;
+  private String shardIndex;
+  private String stderr;
+  private String stdout;
+
+  public int getAttempt() {
+    return attempt;
+  }
+
+  public String getBackend() {
+    return backend;
+  }
+
+  public String getCallRoot() {
+    return callRoot;
+  }
+
+  public String getExecutionStatus() {
+    return executionStatus;
+  }
+
+  public List<CromwellFailure> getFailures() {
+    return failures;
+  }
+
+  public String getJobId() {
+    return jobId;
+  }
+
+  public Long getReturnCode() {
+    return returnCode;
+  }
+
+  public String getShardIndex() {
+    return shardIndex;
+  }
+
+  public String getStderr() {
+    return stderr;
+  }
+
+  public String getStdout() {
+    return stdout;
+  }
+
+  public void setAttempt(int attempt) {
+    this.attempt = attempt;
+  }
+
+  public void setBackend(String backend) {
+    this.backend = backend;
+  }
+
+  public void setCallRoot(String callRoot) {
+    this.callRoot = callRoot;
+  }
+
+  public void setExecutionStatus(String executionStatus) {
+    this.executionStatus = executionStatus;
+  }
+
+  public void setFailures(List<CromwellFailure> failures) {
+    this.failures = failures;
+  }
+
+  public void setJobId(String jobId) {
+    this.jobId = jobId;
+  }
+
+  public void setReturnCode(Long returnCode) {
+    this.returnCode = returnCode;
+  }
+
+  public void setShardIndex(String shardIndex) {
+    this.shardIndex = shardIndex;
+  }
+
+  public void setStderr(String stderr) {
+    this.stderr = stderr;
+  }
+
+  public void setStdout(String stdout) {
+    this.stdout = stdout;
+  }
+}

--- a/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/CromwellFailure.java
+++ b/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/CromwellFailure.java
@@ -1,0 +1,26 @@
+package ca.on.oicr.gsi.vidarr.cromwell;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CromwellFailure {
+  private List<CromwellFailure> causedBy;
+  private String message;
+
+  public List<CromwellFailure> getCausedBy() {
+    return causedBy;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public void setCausedBy(List<CromwellFailure> causedBy) {
+    this.causedBy = causedBy;
+  }
+
+  public void setMessage(String message) {
+    this.message = message;
+  }
+}

--- a/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/CromwellOutputProvisioner.java
+++ b/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/CromwellOutputProvisioner.java
@@ -145,11 +145,11 @@ public class CromwellOutputProvisioner
                   .uri(
                       URI.create(
                           String.format(
-                              "%s/api/workflows/v1/%s/status", baseUrl, state.getCromwellId())))
+                              "%s/api/workflows/v1/%s/metadata", baseUrl, state.getCromwellId())))
                   .timeout(Duration.ofMinutes(1))
                   .GET()
                   .build(),
-              new JsonBodyHandler<>(MAPPER, WorkflowStatusResponse.class))
+              new JsonBodyHandler<>(MAPPER, WorkflowMetadataResponse.class))
           .thenApply(HttpResponse::body)
           .thenAccept(
               s -> {
@@ -159,6 +159,7 @@ public class CromwellOutputProvisioner
                     String.format(
                         "Cromwell job %s on %s is in state %s",
                         state.getCromwellId(), baseUrl, result.getStatus()));
+                    monitor.storeDebugInfo(result.debugInfo());
                 switch (result.getStatus()) {
                   case "Aborted":
                   case "Failed":

--- a/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/CromwellWorkflowEngine.java
+++ b/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/CromwellWorkflowEngine.java
@@ -80,11 +80,11 @@ public final class CromwellWorkflowEngine
                   .uri(
                       URI.create(
                           String.format(
-                              "%s/api/workflows/v1/%s/status", baseUrl, state.getCromwellId())))
+                              "%s/api/workflows/v1/%s/metadata", baseUrl, state.getCromwellId())))
                   .timeout(Duration.ofMinutes(1))
                   .GET()
                   .build(),
-              new JsonBodyHandler<>(MAPPER, WorkflowStatusResponse.class))
+              new JsonBodyHandler<>(MAPPER, WorkflowMetadataResponse.class))
           .thenApply(HttpResponse::body)
           .thenAccept(
               s -> {
@@ -94,6 +94,7 @@ public final class CromwellWorkflowEngine
                     String.format(
                         "Status for Cromwell workflow %s on %s is %s",
                         state.getCromwellId(), baseUrl, result.getStatus()));
+                    monitor.storeDebugInfo(result.debugInfo());
                 switch (result.getStatus()) {
                   case "Aborted":
                   case "Failed":

--- a/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/WorkflowMetadataResponse.java
+++ b/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/WorkflowMetadataResponse.java
@@ -1,0 +1,83 @@
+package ca.on.oicr.gsi.vidarr.cromwell;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+import java.util.Map;
+
+/** The response from Cromwell when requesting the status of a workflow */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class WorkflowMetadataResponse {
+  private Map<String, List<CromwellCall>> calls;
+  private String id;
+  private String status;
+  private String workflowRoot;
+  private List<CromwellFailure> failures = List.of();
+
+  public JsonNode debugInfo() {
+    final var debugInfo = CromwellWorkflowEngine.MAPPER.createObjectNode();
+    debugInfo.put("type", "cromwell");
+    debugInfo.put("cromwellId", id);
+    debugInfo.put("cromwellStatus", status);
+    debugInfo.put("cromwellRoot", workflowRoot);
+    debugInfo.putPOJO("cromwellFailures", failures);
+    final var cromwellCalls = debugInfo.putArray("cromwellCalls");
+    calls.forEach(
+        (task, calls) ->
+            calls.forEach(
+                call -> {
+                  final var callNode = cromwellCalls.addObject();
+                  callNode.put("task", task);
+                  callNode.put("attempt", call.getAttempt());
+                  callNode.put("backend", call.getBackend());
+                  callNode.put("jobId", call.getJobId());
+                  callNode.put("returnCode", call.getReturnCode());
+                  callNode.put("shardIndex", call.getShardIndex());
+                  callNode.put("stderr", call.getStderr());
+                  callNode.put("stdout", call.getStdout());
+                  callNode.put("executionStatus", call.getExecutionStatus());
+                  callNode.putPOJO("failures", call.getFailures());
+                }));
+    return debugInfo;
+  }
+
+  public Map<String, List<CromwellCall>> getCalls() {
+    return calls;
+  }
+
+  public List<CromwellFailure> getFailures() {
+    return failures;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public String getWorkflowRoot() {
+    return workflowRoot;
+  }
+
+  public void setCalls(Map<String, List<CromwellCall>> calls) {
+    this.calls = calls;
+  }
+
+  public void setFailures(List<CromwellFailure> failures) {
+    this.failures = failures;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public void setStatus(String status) {
+    this.status = status;
+  }
+
+  public void setWorkflowRoot(String workflowRoot) {
+    this.workflowRoot = workflowRoot;
+  }
+}

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/BaseJsonInputProvisioner.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/BaseJsonInputProvisioner.java
@@ -44,6 +44,11 @@ public abstract class BaseJsonInputProvisioner<M, S> implements InputProvisioner
       original.scheduleTask(task);
     }
 
+    @Override
+    public void storeDebugInfo(JsonNode information) {
+      original.storeDebugInfo(information);
+    }
+
     public void storeRecoveryInformation(S state) {
       original.storeRecoveryInformation(mapper.valueToTree(state));
     }

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/BaseJsonOutputProvisioner.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/BaseJsonOutputProvisioner.java
@@ -45,6 +45,11 @@ public abstract class BaseJsonOutputProvisioner<M, S, F> implements OutputProvis
       original.scheduleTask(task);
     }
 
+    @Override
+    public void storeDebugInfo(JsonNode information) {
+      original.storeDebugInfo(information);
+    }
+
     public void storeRecoveryInformation(U state) {
       original.storeRecoveryInformation(mapper.valueToTree(state));
     }

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/BaseJsonWorkflowEngine.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/BaseJsonWorkflowEngine.java
@@ -41,6 +41,11 @@ public abstract class BaseJsonWorkflowEngine<S, C, D> implements WorkflowEngine 
       original.scheduleTask(task);
     }
 
+    @Override
+    public void storeDebugInfo(JsonNode information) {
+      original.storeDebugInfo(information);
+    }
+
     public void storeRecoveryInformation(U state) {
       original.storeRecoveryInformation(mapper.valueToTree(state));
     }

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/WorkMonitor.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/WorkMonitor.java
@@ -1,5 +1,6 @@
 package ca.on.oicr.gsi.vidarr;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -85,6 +86,13 @@ public interface WorkMonitor<T, S> {
    * @param task the task to execute
    */
   void scheduleTask(long delay, TimeUnit units, Runnable task);
+
+  /**
+   * Write debugging status information that will be made available to clients
+   *
+   * @param information the current information to be presented
+   */
+  void storeDebugInfo(JsonNode information);
 
   /**
    * Write the recovery information to stable store

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseOperation.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseOperation.java
@@ -47,6 +47,11 @@ public class DatabaseOperation implements ActiveOperation<DSLContext> {
   }
 
   @Override
+  public void debugInfo(JsonNode info, DSLContext transaction) {
+    updateField(ACTIVE_OPERATION.DEBUG_INFO, info, transaction);
+  }
+
+  @Override
   public void log(System.Logger.Level level, String message) {
     System.err.printf("%s: Operation %d: %s\n", level, id, message);
   }

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
@@ -948,6 +948,7 @@ public final class Main implements ServerConfig {
                             DSL.jsonArrayAgg(
                                 DSL.jsonObject(
                                     DSL.jsonEntry("recoveryState", ACTIVE_OPERATION.RECOVERY_STATE),
+                                    DSL.jsonEntry("debugInformation", ACTIVE_OPERATION.DEBUG_INFO),
                                     DSL.jsonEntry("status", ACTIVE_OPERATION.STATUS),
                                     DSL.jsonEntry("type", ACTIVE_OPERATION.TYPE))))
                         .from(ACTIVE_OPERATION)

--- a/vidarr-server/src/main/resources/db/migration/V0002__debug_info.sql
+++ b/vidarr-server/src/main/resources/db/migration/V0002__debug_info.sql
@@ -1,0 +1,1 @@
+ALTER TABLE active_operation ADD COLUMN debug_info jsonb NOT NULL DEFAULT 'null'::jsonb;


### PR DESCRIPTION
- _Add support for debugging information to be exported_: This allows active operations to export debugging status information to the client. This is intended to populate action tiles in Shesmu with interesting information.
- _Add debug information from Cromwell_:   This exports the same Cromwell information currently visible in Shesmu for Cromwell workflows via the debug information mechanism.