### PR TITLE
Allow bulk update of external IDs

### DIFF
--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
@@ -261,6 +261,12 @@ public final class Main implements ServerConfig {
                                         JsonPost.parse(
                                             AddWorkflowVersionRequest.class,
                                             server::addWorkflowVersion))))
+                            .post(
+                                "/api/versions",
+                                monitor(
+                                    new BlockingHandler(
+                                        JsonPost.parse(
+                                            BulkVersionRequest.class, server::updateVersions))))
                             .setFallbackHandler(
                                 new ResourceHandler(
                                     new ClassPathResourceManager(
@@ -1288,6 +1294,17 @@ public final class Main implements ServerConfig {
     } catch (JsonProcessingException e) {
       exchange.setStatusCode(StatusCodes.INTERNAL_SERVER_ERROR);
       exchange.getResponseSender().send(e.getMessage());
+      e.printStackTrace();
+    }
+  }
+
+  private void updateVersions(HttpServerExchange exchange, BulkVersionRequest request) {
+    final var result = processor.updateVersions(request);
+    exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, TextFormat.CONTENT_TYPE_004);
+    exchange.setStatusCode(StatusCodes.OK);
+    try (final var os = exchange.getOutputStream()) {
+      os.write(Integer.toString(result).getBytes(StandardCharsets.UTF_8));
+    } catch (Exception e) {
       e.printStackTrace();
     }
   }

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/dto/BulkVersionRequest.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/dto/BulkVersionRequest.java
@@ -1,0 +1,43 @@
+package ca.on.oicr.gsi.vidarr.server.dto;
+
+import java.util.List;
+
+public final class BulkVersionRequest {
+
+  String newVersionKey;
+  String oldVersionKey;
+  String provider;
+  List<BulkVersionUpdate> updates;
+
+  public String getNewVersionKey() {
+    return newVersionKey;
+  }
+
+  public String getOldVersionKey() {
+    return oldVersionKey;
+  }
+
+  public String getProvider() {
+    return provider;
+  }
+
+  public List<BulkVersionUpdate> getUpdates() {
+    return updates;
+  }
+
+  public void setNewVersionKey(String newVersionKey) {
+    this.newVersionKey = newVersionKey;
+  }
+
+  public void setOldVersionKey(String oldVersionKey) {
+    this.oldVersionKey = oldVersionKey;
+  }
+
+  public void setProvider(String provider) {
+    this.provider = provider;
+  }
+
+  public void setUpdates(List<BulkVersionUpdate> updates) {
+    this.updates = updates;
+  }
+}

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/dto/BulkVersionUpdate.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/dto/BulkVersionUpdate.java
@@ -1,0 +1,33 @@
+package ca.on.oicr.gsi.vidarr.server.dto;
+
+public final class BulkVersionUpdate {
+
+  String add;
+  String id;
+  String old;
+
+  public String getAdd() {
+    return add;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getOld() {
+    return old;
+  }
+
+  public void setAdd(String add) {
+    this.add = add;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public void setOld(String old) {
+    this.old = old;
+  }
+
+}

--- a/vidarr-server/src/main/resources/ca/on/oicr/gsi/vidarr/server/api-docs/vidarr.json
+++ b/vidarr-server/src/main/resources/ca/on/oicr/gsi/vidarr/server/api-docs/vidarr.json
@@ -1169,6 +1169,72 @@
         ]
       }
     },
+    "/api/versions": {
+      "post": {
+        "description": "Update external IDs with new equivalences in bulk.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "newVersionKey": {
+                    "description": "The version key to add. If adding a new version of the same type, this might be the same as the old version key.",
+                    "type": "string"
+                  },
+                  "oldVersionKey": {
+                    "description": "The version key to search for. An external identifier will be updated if this key is present and matches the per record value",
+                    "type": "string"
+                  },
+                  "provider": {
+                    "description": "The provider to be used for all identifiers",
+                    "type": "string"
+                  },
+                  "updates": {
+                    "description": "The updates to make.",
+                    "items": {
+                      "properties": {
+                        "add": {
+                          "description": "The new value to insert using the new version key.",
+                          "type": "string"
+                        },
+                        "identifer": {
+                          "description": "The external identifier's name.",
+                          "type": "string"
+                        },
+                        "old": {
+                          "description": "The existing value that must be present as a value under the old version key to permit the new value to be inserted.",
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          },
+          "description": "TODO"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            },
+            "description": "The number of records update."
+          }
+        },
+        "summary": "Update external versions",
+        "tags": [
+          "workflow-run"
+        ]
+      }
+    },
     "/api/workflow/{name}": {
       "delete": {
         "description": "Deactivate a workflow. This does not stop inflight actions from using this workflow. It merely stops it from being available in the workflow catalogue.",


### PR DESCRIPTION
Creates an endpoint that allows bulk updating external IDs. This is intended
for LIMS upgrades.