### PR TITLE
Allow restarting failed workflows

### DIFF
--- a/vidarr-cli/src/main/java/ca/on/oicr/gsi/vidarr/cli/SingleShotOperation.java
+++ b/vidarr-cli/src/main/java/ca/on/oicr/gsi/vidarr/cli/SingleShotOperation.java
@@ -21,6 +21,11 @@ final class SingleShotOperation implements ActiveOperation<Void> {
   }
 
   @Override
+  public boolean isLive() {
+    return true;
+  }
+
+  @Override
   public void log(System.Logger.Level level, String message) {
     singleShotWorkflow.log(level, message);
   }

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/ActiveOperation.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/ActiveOperation.java
@@ -15,6 +15,13 @@ public interface ActiveOperation<TX> {
    * @param transaction the transaction to perform the update in
    */
   void debugInfo(JsonNode info, TX transaction);
+
+  /**
+   * Check if the operation is still live
+   *
+   * @return if false, no callbacks will be scheduled.
+   */
+  boolean isLive();
   /**
    * Be told something something interesting
    *

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseOperation.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseOperation.java
@@ -6,41 +6,52 @@ import ca.on.oicr.gsi.vidarr.core.ActiveOperation;
 import ca.on.oicr.gsi.vidarr.core.OperationStatus;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.jooq.DSLContext;
 import org.jooq.Field;
 import org.jooq.Record;
 
 public class DatabaseOperation implements ActiveOperation<DSLContext> {
   public static Optional<DatabaseOperation> create(
-      DSLContext dsl, int workflowId, String type, JsonNode recoveryState) {
+      DSLContext dsl,
+      int workflowId,
+      String type,
+      JsonNode recoveryState,
+      int attempt,
+      AtomicBoolean liveness) {
     return dsl.insertInto(ACTIVE_OPERATION)
         .set(ACTIVE_OPERATION.TYPE, type)
         .set(ACTIVE_OPERATION.STATUS, OperationStatus.INITIALIZING)
         .set(ACTIVE_OPERATION.WORKFLOW_RUN_ID, workflowId)
+        .set(ACTIVE_OPERATION.ATTEMPT, attempt)
         .set(ACTIVE_OPERATION.RECOVERY_STATE, recoveryState)
         .returningResult(ACTIVE_OPERATION.ID)
         .fetchOptional()
         .map(
             id ->
                 new DatabaseOperation(
-                    id.value1(), recoveryState, OperationStatus.INITIALIZING, ""));
+                    id.value1(), liveness, recoveryState, OperationStatus.INITIALIZING, ""));
   }
 
-  public static DatabaseOperation recover(Record record) {
+  public static DatabaseOperation recover(Record record, AtomicBoolean liveness) {
     return new DatabaseOperation(
         record.get(ACTIVE_OPERATION.ID),
+        liveness,
         record.get(ACTIVE_OPERATION.RECOVERY_STATE),
         record.get(ACTIVE_OPERATION.STATUS),
         record.get(ACTIVE_OPERATION.TYPE));
   }
 
   private final int id;
+  private final AtomicBoolean liveness;
   private JsonNode recoveryState;
   private OperationStatus status;
   private String type;
 
-  private DatabaseOperation(int id, JsonNode recoveryState, OperationStatus status, String type) {
+  private DatabaseOperation(
+      int id, AtomicBoolean liveness, JsonNode recoveryState, OperationStatus status, String type) {
     this.id = id;
+    this.liveness = liveness;
     this.recoveryState = recoveryState;
     this.status = status;
     this.type = type;
@@ -49,6 +60,11 @@ public class DatabaseOperation implements ActiveOperation<DSLContext> {
   @Override
   public void debugInfo(JsonNode info, DSLContext transaction) {
     updateField(ACTIVE_OPERATION.DEBUG_INFO, info, transaction);
+  }
+
+  @Override
+  public boolean isLive() {
+    return liveness.get();
   }
 
   @Override
@@ -90,10 +106,12 @@ public class DatabaseOperation implements ActiveOperation<DSLContext> {
   }
 
   private <T> void updateField(Field<T> field, T value, DSLContext transaction) {
-    transaction
-        .update(ACTIVE_OPERATION)
-        .set(field, value)
-        .where(ACTIVE_OPERATION.ID.eq(id))
-        .execute();
+    if (liveness.get()) {
+      transaction
+          .update(ACTIVE_OPERATION)
+          .set(field, value)
+          .where(ACTIVE_OPERATION.ID.eq(id))
+          .execute();
+    }
   }
 }

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/dto/BulkVersionUpdate.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/dto/BulkVersionUpdate.java
@@ -29,5 +29,4 @@ public final class BulkVersionUpdate {
   public void setOld(String old) {
     this.old = old;
   }
-
 }

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/dto/SubmitWorkflowRequest.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/dto/SubmitWorkflowRequest.java
@@ -9,6 +9,7 @@ import java.util.Set;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class SubmitWorkflowRequest {
   private ObjectNode arguments;
+  private int attempt;
   private Map<String, Long> consumableResources;
   private ObjectNode engineParameters;
   private Set<ExternalKey> externalKeys;
@@ -21,6 +22,10 @@ public final class SubmitWorkflowRequest {
 
   public ObjectNode getArguments() {
     return arguments;
+  }
+
+  public int getAttempt() {
+    return attempt;
   }
 
   public Map<String, Long> getConsumableResources() {
@@ -61,6 +66,10 @@ public final class SubmitWorkflowRequest {
 
   public void setArguments(ObjectNode arguments) {
     this.arguments = arguments;
+  }
+
+  public void setAttempt(int attempt) {
+    this.attempt = attempt;
   }
 
   public void setConsumableResources(Map<String, Long> consumableResources) {

--- a/vidarr-server/src/main/resources/ca/on/oicr/gsi/vidarr/server/api-docs/vidarr.json
+++ b/vidarr-server/src/main/resources/ca/on/oicr/gsi/vidarr/server/api-docs/vidarr.json
@@ -971,6 +971,9 @@
                     "additionalProperties": true,
                     "type": "object"
                   },
+                  "attempt": {
+                    "type": "integer"
+                  },
                   "consumableResources": {
                     "additionalProperties": {
                       "type": "integer"

--- a/vidarr-server/src/main/resources/db/migration/V0002__debug_info.sql
+++ b/vidarr-server/src/main/resources/db/migration/V0002__debug_info.sql
@@ -1,1 +1,4 @@
 ALTER TABLE active_operation ADD COLUMN debug_info jsonb NOT NULL DEFAULT 'null'::jsonb;
+
+ALTER TABLE active_workflow_run ADD COLUMN attempt integer NOT NULL DEFAULT 0;
+ALTER TABLE active_operation ADD COLUMN attempt integer NOT NULL DEFAULT 0;


### PR DESCRIPTION
This adds an attempt number that a client can use to restart a failed workflow.
It also restart failed workflows if a new version of the workflow is available.

To accomplish this, there is an attempt number and if the workflow is failed
and the client sends a higher attempt number, the steps in the workflow will be
restarted (after updating the arguments).