### PR TITLE
Remove support for optional parameters

### DIFF
--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseProcessor.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseProcessor.java
@@ -264,7 +264,7 @@ public abstract class BaseProcessor<
                                               return file;
                                             },
                                             provisionInTasks::add)));
-                          } else if (parameter.isRequired()) {
+                          } else {
                             throw new IllegalArgumentException(
                                 String.format("Missing required parameter: %s", parameter.name()));
                           }
@@ -685,9 +685,9 @@ public abstract class BaseProcessor<
         .parameters()
         .flatMap(
             p ->
-                p.isRequired() || arguments.has(p.name())
+                arguments.has(p.name())
                     ? p.type().apply(new ExtractInputVidarrIds(mapper, arguments.get(p.name())))
-                    : Stream.empty())
+                    : Stream.of("Missing input parameter: " + p.name()))
         .distinct();
   }
 
@@ -728,9 +728,7 @@ public abstract class BaseProcessor<
                             return p.type()
                                 .apply(new CheckInputType(mapper, target, arguments.get(p.name())));
                           } else {
-                            return p.isRequired()
-                                ? Stream.of("Required argument missing: " + p.name())
-                                : Stream.empty();
+                            return Stream.of("Argument missing: " + p.name());
                           }
                         }),
                 target

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseWorkflowConfiguration.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseWorkflowConfiguration.java
@@ -7,30 +7,10 @@ import java.util.Map;
 
 /** JSON representation of a workflow definition */
 public abstract class BaseWorkflowConfiguration {
-  public static final class Parameter {
-    private boolean required = true;
-    private InputType type;
-
-    public InputType getType() {
-      return type;
-    }
-
-    public boolean isRequired() {
-      return required;
-    }
-
-    public void setRequired(boolean required) {
-      this.required = required;
-    }
-
-    public void setType(InputType type) {
-      this.type = type;
-    }
-  }
 
   private WorkflowLanguage language;
   private Map<String, OutputProvisionType> outputs;
-  private Map<String, Parameter> parameters;
+  private Map<String, InputType> parameters;
   private String workflow;
 
   public final WorkflowLanguage getLanguage() {
@@ -41,7 +21,7 @@ public abstract class BaseWorkflowConfiguration {
     return outputs;
   }
 
-  public final Map<String, Parameter> getParameters() {
+  public final Map<String, InputType> getParameters() {
     return parameters;
   }
 
@@ -57,7 +37,7 @@ public abstract class BaseWorkflowConfiguration {
     this.outputs = outputs;
   }
 
-  public final void setParameters(Map<String, Parameter> parameters) {
+  public final void setParameters(Map<String, InputType> parameters) {
     this.parameters = parameters;
   }
 

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/WorkflowConfiguration.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/WorkflowConfiguration.java
@@ -17,10 +17,7 @@ public class WorkflowConfiguration extends BaseWorkflowConfiguration {
         id,
         getWorkflow(),
         getParameters().entrySet().stream()
-            .map(
-                p ->
-                    new WorkflowDefinition.Parameter(
-                        p.getValue().getType(), p.getKey(), p.getValue().isRequired())),
+            .map(p -> new WorkflowDefinition.Parameter(p.getValue(), p.getKey())),
         getOutputs().entrySet().stream()
             .map(o -> new WorkflowDefinition.Output(o.getValue(), o.getKey())));
   }

--- a/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/EngineState.java
+++ b/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/EngineState.java
@@ -10,7 +10,7 @@ public final class EngineState {
   private ObjectNode parameters;
   private String vidarrId;
   private WorkflowLanguage workflowLanguage;
-  private String workflowUrl;
+  private String workflowSource;
 
   public String getCromwellId() {
     return cromwellId;
@@ -32,8 +32,8 @@ public final class EngineState {
     return workflowLanguage;
   }
 
-  public String getWorkflowUrl() {
-    return workflowUrl;
+  public String getWorkflowSource() {
+    return workflowSource;
   }
 
   public void setCromwellId(String cromwellId) {
@@ -56,7 +56,7 @@ public final class EngineState {
     this.workflowLanguage = workflowLanguage;
   }
 
-  public void setWorkflowUrl(String workflowUrl) {
-    this.workflowUrl = workflowUrl;
+  public void setWorkflowSource(String workflowSource) {
+    this.workflowSource = workflowSource;
   }
 }

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/WorkflowDefinition.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/WorkflowDefinition.java
@@ -38,7 +38,6 @@ public final class WorkflowDefinition {
   /** A parameter that can be supplied to a workflow. */
   public static final class Parameter {
     private final String name;
-    private final boolean required;
     private final InputType type;
 
     /**
@@ -46,17 +45,10 @@ public final class WorkflowDefinition {
      *
      * @param type the type of the value the caller must supply
      * @param name the name the caller must supply
-     * @param required whether this parameter is strictly required
      */
-    public Parameter(InputType type, String name, boolean required) {
+    public Parameter(InputType type, String name) {
       this.type = type;
       this.name = name;
-      this.required = required;
-    }
-
-    /** Whether this parameter is strictly required */
-    public boolean isRequired() {
-      return required;
     }
 
     /** The name the caller must supply */

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.vidarr.server;
 import static ca.on.oicr.gsi.vidarr.server.jooq.Tables.*;
 
 import ca.on.oicr.gsi.Pair;
+import ca.on.oicr.gsi.vidarr.InputType;
 import ca.on.oicr.gsi.vidarr.OutputProvisionType;
 import ca.on.oicr.gsi.vidarr.SimpleType;
 import ca.on.oicr.gsi.vidarr.WorkflowDefinition;
@@ -126,8 +127,8 @@ public abstract class DatabaseBackedProcessor
   static final ObjectMapper MAPPER = new ObjectMapper();
   public static final TypeReference<Map<String, OutputProvisionType>> OUTPUT_JSON_TYPE =
       new TypeReference<>() {};
-  public static final TypeReference<Map<String, WorkflowConfiguration.Parameter>>
-      PARAMETER_JSON_TYPE = new TypeReference<>() {};
+  public static final TypeReference<Map<String, InputType>> PARAMETER_JSON_TYPE =
+      new TypeReference<>() {};
 
   private static WorkflowDefinition buildDefinitionFromRecord(org.jooq.Record record) {
     return new WorkflowDefinition(
@@ -138,10 +139,7 @@ public abstract class DatabaseBackedProcessor
             .convertValue(record.get(WORKFLOW_VERSION.PARAMETERS), PARAMETER_JSON_TYPE)
             .entrySet()
             .stream()
-            .map(
-                e ->
-                    new WorkflowDefinition.Parameter(
-                        e.getValue().getType(), e.getKey(), e.getValue().isRequired())),
+            .map(e -> new WorkflowDefinition.Parameter(e.getValue(), e.getKey())),
         MAPPER
             .convertValue(record.get(WORKFLOW_VERSION.METADATA), OUTPUT_JSON_TYPE)
             .entrySet()


### PR DESCRIPTION
Input parameters had the idea of being _required_. This was a copy of a design
in Shesmu for dealing with Cromwell and it can be replaced by something
simpler. Shesmu and Vidarr have the idea of optional values where a missing
value is encoded as JSON null. Cromwell has the idea of an optional value with
the same encoding, but also has parameters which should use a default, which
needed to be encoded as absent. Shesmu and Vidarr aped this "two ways to say
nothing" approach for compatibility, but this change unifies them. Shesmu and
Vidarr always encode optional values as null and the nulls are erased before
being passed to Cromwell.