### PR TITLE
Remove tagged unions in output types

### DIFF
--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/CheckOutputType.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/CheckOutputType.java
@@ -50,11 +50,6 @@ public final class CheckOutputType extends BaseOutputExtractor<Stream<String>, S
   }
 
   @Override
-  protected Stream<String> taggedUnion(OutputProvisionType type, JsonNode metadata) {
-    return type.apply(new CheckOutputType(mapper, target, metadata));
-  }
-
-  @Override
   public Stream<String> unknown() {
     return Stream.of("Unknown data type");
   }

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/PrepareOutputProvisioning.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/PrepareOutputProvisioning.java
@@ -142,14 +142,6 @@ final class PrepareOutputProvisioning
   }
 
   @Override
-  protected Stream<TaskStarter<Pair<ProvisionData, Result>>> taggedUnion(
-      OutputProvisionType type, JsonNode metadata) {
-    return type.apply(
-        new PrepareOutputProvisioning(
-            mapper, target, output, metadata, allInputIds, remainingInputIds));
-  }
-
-  @Override
   public Stream<TaskStarter<Pair<ProvisionData, Result>>> unknown() {
     throw new IllegalArgumentException();
   }

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/PreparePreflightChecks.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/PreparePreflightChecks.java
@@ -89,13 +89,6 @@ final class PreparePreflightChecks extends BaseOutputExtractor<Boolean, Boolean>
   }
 
   @Override
-  protected Boolean taggedUnion(OutputProvisionType type, JsonNode metadata) {
-    return type.apply(
-        new PreparePreflightChecks(
-            mapper, target, metadata, extraInputIdsHandled, requestedExternalId, preflightTask));
-  }
-
-  @Override
   public Boolean unknown() {
     return false;
   }

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/OutputProvisioner.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/OutputProvisioner.java
@@ -126,8 +126,6 @@ public interface OutputProvisioner {
   /**
    * Get the type of information required for provisioning out the files
    *
-   * <p>The fields will be mixed the Vidarr's own fields, which all start with <tt>vidarr</tt>.
-   *
    * @param format the input format
    * @return the metadata that the client must supply to be able to provision in this data
    */


### PR DESCRIPTION
I had added tagged unions to both input and output types. When implementing
them in the Shesmu plugin, two problems became obvious:
- the design would produce broken JSON structures
- having them might allow output files to be lost

Since we decided that all output files must be captured and since WDL cannot
produced tagged unions natively, it is easiest to drop this feature.