### PR TITLE
Change engine arguments to be any JSON type

### DIFF
--- a/vidarr-cli/src/main/java/ca/on/oicr/gsi/vidarr/cli/CommandRunner.java
+++ b/vidarr-cli/src/main/java/ca/on/oicr/gsi/vidarr/cli/CommandRunner.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.vidarr.cli;
 import ca.on.oicr.gsi.vidarr.core.ExternalId;
 import ca.on.oicr.gsi.vidarr.core.OutputProvisioningHandler;
 import ca.on.oicr.gsi.vidarr.core.WorkflowConfiguration;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.File;
@@ -18,11 +19,11 @@ import picocli.CommandLine;
     name = "run",
     description = "Run a workflow and dump the provisioning records to a file")
 public class CommandRunner implements Callable<Integer> {
-  private static ObjectNode read(String argument) throws IOException {
+  private static <T> T read(String argument, Class<T> clazz) throws IOException {
     if (argument.startsWith("@")) {
-      return MAPPER.readValue(new File(argument.substring(1)), ObjectNode.class);
+      return MAPPER.readValue(new File(argument.substring(1)), clazz);
     } else {
-      return MAPPER.readValue(argument, ObjectNode.class);
+      return MAPPER.readValue(argument, clazz);
     }
   }
 
@@ -77,9 +78,9 @@ public class CommandRunner implements Callable<Integer> {
         "run",
         target,
         workflow,
-        read(arguments),
-        read(metadata),
-        read(engineArguments),
+        read(arguments, ObjectNode.class),
+        read(metadata, ObjectNode.class),
+        read(engineArguments, JsonNode.class),
         new OutputProvisioningHandler<>() {
 
           @Override

--- a/vidarr-cli/src/main/java/ca/on/oicr/gsi/vidarr/cli/SingleShotProcessor.java
+++ b/vidarr-cli/src/main/java/ca/on/oicr/gsi/vidarr/cli/SingleShotProcessor.java
@@ -2,6 +2,7 @@ package ca.on.oicr.gsi.vidarr.cli;
 
 import ca.on.oicr.gsi.vidarr.WorkflowDefinition;
 import ca.on.oicr.gsi.vidarr.core.*;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.time.Instant;
@@ -43,7 +44,7 @@ final class SingleShotProcessor
       WorkflowDefinition workflow,
       ObjectNode arguments,
       ObjectNode metadata,
-      ObjectNode engineParameters,
+      JsonNode engineParameters,
       OutputProvisioningHandler<Void> outputHandler) {
     final SingleShotWorkflow active =
         startAsync(prefix, target, workflow, arguments, metadata, engineParameters, outputHandler);
@@ -57,7 +58,7 @@ final class SingleShotProcessor
       WorkflowDefinition workflow,
       ObjectNode arguments,
       ObjectNode metadata,
-      ObjectNode engineParameters,
+      JsonNode engineParameters,
       OutputProvisioningHandler<Void> outputHandler) {
     System.err.printf("%s: [%s] Validating input...%n", prefix, Instant.now());
     final List<String> errors =

--- a/vidarr-cli/src/main/java/ca/on/oicr/gsi/vidarr/cli/SingleShotWorkflow.java
+++ b/vidarr-cli/src/main/java/ca/on/oicr/gsi/vidarr/cli/SingleShotWorkflow.java
@@ -15,7 +15,7 @@ import java.util.stream.Stream;
 final class SingleShotWorkflow implements ActiveWorkflow<SingleShotOperation, Void> {
   private final JsonNode arguments;
   private JsonNode cleanup;
-  private final ObjectNode engineArguments;
+  private final JsonNode engineArguments;
   private Set<ExternalId> externalIds;
   private boolean extraInputIdsHandled;
   private final CompletableFuture<Boolean> future = new CompletableFuture<>();
@@ -30,7 +30,7 @@ final class SingleShotWorkflow implements ActiveWorkflow<SingleShotOperation, Vo
   SingleShotWorkflow(
       String prefix,
       JsonNode arguments,
-      ObjectNode engineArguments,
+      JsonNode engineArguments,
       JsonNode metadata,
       Stream<ExternalId> inputIds,
       OutputProvisioningHandler<Void> resultHandler) {
@@ -62,7 +62,7 @@ final class SingleShotWorkflow implements ActiveWorkflow<SingleShotOperation, Vo
   }
 
   @Override
-  public ObjectNode engineArguments() {
+  public JsonNode engineArguments() {
     return engineArguments;
   }
 

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/ActiveWorkflow.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/ActiveWorkflow.java
@@ -30,8 +30,12 @@ public interface ActiveWorkflow<O extends ActiveOperation<TX>, TX>
    */
   void cleanup(JsonNode cleanupState, TX transaction);
 
-  /** Get the caller-supplied engine argument to the workflow run */
-  ObjectNode engineArguments();
+  /**
+   * Get the caller-supplied engine argument to the workflow run
+   *
+   * @return
+   */
+  JsonNode engineArguments();
 
   /**
    * Check if extra input is handled

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseProcessor.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseProcessor.java
@@ -710,7 +710,7 @@ public abstract class BaseProcessor<
       WorkflowDefinition workflow,
       JsonNode arguments,
       JsonNode metadata,
-      ObjectNode engineParameters) {
+      JsonNode engineParameters) {
     return Stream.concat(
         target.engine().supports(workflow.language())
             ? Stream.empty()

--- a/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/CromwellWorkflowEngine.java
+++ b/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/CromwellWorkflowEngine.java
@@ -298,7 +298,7 @@ public final class CromwellWorkflowEngine
       String workflow,
       String vidarrId,
       ObjectNode workflowParameters,
-      ObjectNode engineParameters,
+      JsonNode engineParameters,
       WorkMonitor<Result<String>, EngineState> monitor) {
     final var state = new EngineState();
     /* Cromwell and Shesmu/Vidarr handle optional parameters differently.

--- a/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/EngineState.java
+++ b/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/EngineState.java
@@ -1,12 +1,13 @@
 package ca.on.oicr.gsi.vidarr.cromwell;
 
 import ca.on.oicr.gsi.vidarr.WorkflowLanguage;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /** The current state of a running workflow to be recorded in the database */
 public final class EngineState {
   private String cromwellId;
-  private ObjectNode engineParameters;
+  private JsonNode engineParameters;
   private ObjectNode parameters;
   private String vidarrId;
   private WorkflowLanguage workflowLanguage;
@@ -16,7 +17,7 @@ public final class EngineState {
     return cromwellId;
   }
 
-  public ObjectNode getEngineParameters() {
+  public JsonNode getEngineParameters() {
     return engineParameters;
   }
 
@@ -40,7 +41,7 @@ public final class EngineState {
     this.cromwellId = cromwellId;
   }
 
-  public void setEngineParameters(ObjectNode engineParameters) {
+  public void setEngineParameters(JsonNode engineParameters) {
     this.engineParameters = engineParameters;
   }
 

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/BaseJsonWorkflowEngine.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/BaseJsonWorkflowEngine.java
@@ -159,7 +159,7 @@ public abstract class BaseJsonWorkflowEngine<S, C, D> implements WorkflowEngine 
       String workflow,
       String vidarrId,
       ObjectNode workflowParameters,
-      ObjectNode engineParameters,
+      JsonNode engineParameters,
       WorkMonitor<Result<JsonNode>, JsonNode> monitor) {
     return mapper.valueToTree(
         runWorkflow(
@@ -173,13 +173,13 @@ public abstract class BaseJsonWorkflowEngine<S, C, D> implements WorkflowEngine 
   /**
    * Start a new workflow
    *
-   * @see WorkflowEngine#run(WorkflowLanguage, String, String, ObjectNode, ObjectNode, WorkMonitor)
+   * @see WorkflowEngine#run(WorkflowLanguage, String, String, ObjectNode, JsonNode, WorkMonitor)
    */
   protected abstract S runWorkflow(
       WorkflowLanguage workflowLanguage,
       String workflow,
       String vidarrId,
       ObjectNode workflowParameters,
-      ObjectNode engineParameters,
+      JsonNode engineParameters,
       WorkMonitor<Result<C>, S> monitor);
 }

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/WorkflowEngine.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/WorkflowEngine.java
@@ -101,7 +101,7 @@ public interface WorkflowEngine {
       String workflow,
       String vidarrId,
       ObjectNode workflowParameters,
-      ObjectNode engineParameters,
+      JsonNode engineParameters,
       WorkMonitor<Result<JsonNode>, JsonNode> monitor);
 
   /**

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
@@ -374,7 +374,7 @@ public abstract class DatabaseBackedProcessor
       String version,
       ObjectNode labels,
       JsonNode arguments,
-      ObjectNode engineParameters,
+      JsonNode engineParameters,
       JsonNode metadata,
       Set<ExternalKey> externalKeys,
       int attempt,

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseWorkflow.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseWorkflow.java
@@ -33,7 +33,7 @@ public class DatabaseWorkflow implements ActiveWorkflow<DatabaseOperation, DSLCo
       String vidarrId,
       ObjectNode labels,
       JsonNode arguments,
-      ObjectNode engineParameters,
+      JsonNode engineParameters,
       JsonNode metadata,
       SortedSet<String> fileIds,
       Set<? extends ExternalId> ids,
@@ -243,7 +243,7 @@ public class DatabaseWorkflow implements ActiveWorkflow<DatabaseOperation, DSLCo
   private final JsonNode arguments;
   private final int attempt;
   private JsonNode cleanup;
-  private final ObjectNode engineArguments;
+  private final JsonNode engineArguments;
   private boolean extraInputIdsHandled;
   private final int id;
   private final Set<ExternalId> inputIds;
@@ -260,7 +260,7 @@ public class DatabaseWorkflow implements ActiveWorkflow<DatabaseOperation, DSLCo
       String vidarrId,
       int attempt,
       JsonNode arguments,
-      ObjectNode engineArguments,
+      JsonNode engineArguments,
       JsonNode metadata,
       JsonNode cleanup,
       boolean extraInputIdsHandled,
@@ -330,7 +330,7 @@ public class DatabaseWorkflow implements ActiveWorkflow<DatabaseOperation, DSLCo
   }
 
   @Override
-  public ObjectNode engineArguments() {
+  public JsonNode engineArguments() {
     return engineArguments;
   }
 

--- a/vidarr-sh/src/main/java/ca/on/oicr/gsi/vidarr/sh/UnixShellWorkflowEngine.java
+++ b/vidarr-sh/src/main/java/ca/on/oicr/gsi/vidarr/sh/UnixShellWorkflowEngine.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.vidarr.sh;
 import ca.on.oicr.gsi.status.SectionRenderer;
 import ca.on.oicr.gsi.vidarr.*;
 import ca.on.oicr.gsi.vidarr.WorkMonitor.Status;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.File;
@@ -91,7 +92,7 @@ public final class UnixShellWorkflowEngine
       String workflow,
       String vidarrId,
       ObjectNode workflowParameters,
-      ObjectNode engineParameters,
+      JsonNode engineParameters,
       WorkMonitor<Result<String>, ShellState> monitor) {
     final var state = new ShellState();
     monitor.scheduleTask(


### PR DESCRIPTION
The API for `WorkflowEngine` allows the workflow engine to specify the workflow
parameters to be any type, however, it was be marshalled as an object node
along the way. Though that is the most sensible type for this value, the two
APIs need to match.