### PR TITLE
Add additional DTOs

### DIFF
--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/AddWorkflowRequest.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/AddWorkflowRequest.java
@@ -1,9 +1,11 @@
 package ca.on.oicr.gsi.vidarr.api;
 
 import ca.on.oicr.gsi.vidarr.BasicType;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.Collections;
 import java.util.Map;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class AddWorkflowRequest {
   private Map<String, Long> consumableResources = Collections.emptyMap();
   private Map<String, BasicType> labels = Collections.emptyMap();

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/AddWorkflowVersionRequest.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/AddWorkflowVersionRequest.java
@@ -1,3 +1,6 @@
 package ca.on.oicr.gsi.vidarr.api;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public final class AddWorkflowVersionRequest extends BaseWorkflowConfiguration {}

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/AnalysisProvenanceResponse.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/AnalysisProvenanceResponse.java
@@ -1,0 +1,42 @@
+package ca.on.oicr.gsi.vidarr.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+/**
+ * The workflow runs fetched by an analysis provenance request
+ *
+ * @param <V> the type of version keys that will be returned; {@link
+ *     AnalysisProvenanceRequest#setVersionPolicy(VersionPolicy)} will set the type that should be
+ *     used here. See {@link VersionPolicy} for details.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class AnalysisProvenanceResponse<V extends ExternalId> {
+  private long epoch;
+  private List<ProvenanceWorkflowRun<V>> results;
+  private long timestamp;
+
+  public long getEpoch() {
+    return epoch;
+  }
+
+  public List<ProvenanceWorkflowRun<V>> getResults() {
+    return results;
+  }
+
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  public void setEpoch(long epoch) {
+    this.epoch = epoch;
+  }
+
+  public void setResults(List<ProvenanceWorkflowRun<V>> results) {
+    this.results = results;
+  }
+
+  public void setTimestamp(long timestamp) {
+    this.timestamp = timestamp;
+  }
+}

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/ExternalId.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/ExternalId.java
@@ -1,8 +1,10 @@
 package ca.on.oicr.gsi.vidarr.api;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.Objects;
 
 /** A reference to an external key */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ExternalId {
 
   private String id;

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/ExternalKey.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/ExternalKey.java
@@ -1,8 +1,10 @@
 package ca.on.oicr.gsi.vidarr.api;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.Map;
 
 /** A reference to an external key with version information */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public final class ExternalKey extends ExternalId {
 
   private Map<String, String> versions;

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/ExternalMultiVersionKey.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/ExternalMultiVersionKey.java
@@ -1,0 +1,20 @@
+package ca.on.oicr.gsi.vidarr.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Map;
+import java.util.Set;
+
+/** A reference to an external key with all versions available */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class ExternalMultiVersionKey extends ExternalId {
+
+  private Map<String, Set<String>> versions;
+
+  public Map<String, Set<String>> getVersions() {
+    return versions;
+  }
+
+  public void setVersions(Map<String, Set<String>> versions) {
+    this.versions = versions;
+  }
+}

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/ProvenanceAnalysisRecord.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/ProvenanceAnalysisRecord.java
@@ -6,9 +6,9 @@ import java.util.List;
 import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class AnalysisRecordDto {
+public class ProvenanceAnalysisRecord<K extends ExternalId> {
   private ZonedDateTime created;
-  private List<ExternalKey> externalKeys;
+  private List<K> externalKeys;
   private String filePath;
   private long fileSize;
   private String id;
@@ -23,7 +23,7 @@ public class AnalysisRecordDto {
     return created;
   }
 
-  public List<ExternalKey> getExternalKeys() {
+  public List<K> getExternalKeys() {
     return externalKeys;
   }
 
@@ -67,7 +67,7 @@ public class AnalysisRecordDto {
     this.created = created;
   }
 
-  public void setExternalKeys(List<ExternalKey> externalKeys) {
+  public void setExternalKeys(List<K> externalKeys) {
     this.externalKeys = externalKeys;
   }
 

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/ProvenanceWorkflowRun.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/ProvenanceWorkflowRun.java
@@ -1,0 +1,127 @@
+package ca.on.oicr.gsi.vidarr.api;
+
+import ca.on.oicr.gsi.Pair;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class ProvenanceWorkflowRun<K extends ExternalId> {
+
+  private List<ProvenanceAnalysisRecord<ExternalId>> analysis;
+  private ZonedDateTime completed;
+  private ZonedDateTime created;
+  private List<K> externalKeys;
+  private String id;
+  private List<String> inputFiles;
+  private String instanceName;
+  private Map<String, String> labels;
+  private ZonedDateTime modified;
+  private ZonedDateTime started;
+  private String workflowName;
+  private String workflowVersion;
+
+  public List<ProvenanceAnalysisRecord<ExternalId>> getAnalysis() {
+    return analysis;
+  }
+
+  public ZonedDateTime getCompleted() {
+    return completed;
+  }
+
+  public ZonedDateTime getCreated() {
+    return created;
+  }
+
+  public List<K> getExternalKeys() {
+    return externalKeys;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public List<String> getInputFiles() {
+    return inputFiles;
+  }
+
+  @JsonIgnore
+  public String getInstanceName() {
+    return instanceName;
+  }
+
+  public Map<String, String> getLabels() {
+    return labels;
+  }
+
+  public ZonedDateTime getModified() {
+    return modified;
+  }
+
+  public ZonedDateTime getStarted() {
+    return started;
+  }
+
+  public String getWorkflowName() {
+    return workflowName;
+  }
+
+  public String getWorkflowVersion() {
+    return workflowVersion;
+  }
+
+  public Stream<Pair<String, String>> key() {
+    return externalKeys.stream().map(k -> new Pair<>(k.getProvider(), k.getId()));
+  }
+
+  public void setAnalysis(List<ProvenanceAnalysisRecord<ExternalId>> analysis) {
+    this.analysis = analysis;
+  }
+
+  public void setCompleted(ZonedDateTime completed) {
+    this.completed = completed;
+  }
+
+  public void setCreated(ZonedDateTime created) {
+    this.created = created;
+  }
+
+  public void setExternalKeys(List<K> externalKeys) {
+    this.externalKeys = externalKeys;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public void setInputFiles(List<String> inputFiles) {
+    this.inputFiles = inputFiles;
+  }
+
+  public void setInstanceName(String instanceName) {
+    this.instanceName = instanceName;
+  }
+
+  public void setLabels(Map<String, String> labels) {
+    this.labels = labels;
+  }
+
+  public void setModified(ZonedDateTime modified) {
+    this.modified = modified;
+  }
+
+  public void setStarted(ZonedDateTime started) {
+    this.started = started;
+  }
+
+  public void setWorkflowName(String workflowName) {
+    this.workflowName = workflowName;
+  }
+
+  public void setWorkflowVersion(String workflowVersion) {
+    this.workflowVersion = workflowVersion;
+  }
+}

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/VersionPolicy.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/VersionPolicy.java
@@ -1,7 +1,20 @@
 package ca.on.oicr.gsi.vidarr.api;
 
+/** Set the type of version information return with workflow run provenance */
 public enum VersionPolicy {
+  /**
+   * All known values associated with a version are returned. Use {@link ExternalMultiVersionKey} as
+   * the type argument to {@link AnalysisProvenanceResponse}.
+   */
   ALL,
+  /**
+   * Only the newest value associated with a version is returned. Use {@link ExternalKey} as the
+   * type argument to {@link AnalysisProvenanceResponse}.
+   */
   LATEST,
+  /**
+   * No version values are returned. Use {@link ExternalId} as the type argument to {@link
+   * AnalysisProvenanceResponse}.
+   */
   NONE
 }

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
@@ -10,8 +10,8 @@ import ca.on.oicr.gsi.vidarr.api.AddWorkflowRequest;
 import ca.on.oicr.gsi.vidarr.api.AddWorkflowVersionRequest;
 import ca.on.oicr.gsi.vidarr.api.AnalysisOutputType;
 import ca.on.oicr.gsi.vidarr.api.AnalysisProvenanceRequest;
-import ca.on.oicr.gsi.vidarr.api.AnalysisRecordDto;
 import ca.on.oicr.gsi.vidarr.api.ExternalKey;
+import ca.on.oicr.gsi.vidarr.api.ProvenanceAnalysisRecord;
 import ca.on.oicr.gsi.vidarr.api.SubmitMode;
 import ca.on.oicr.gsi.vidarr.api.SubmitWorkflowRequest;
 import ca.on.oicr.gsi.vidarr.api.SubmitWorkflowResponse;
@@ -34,6 +34,7 @@ import ca.on.oicr.gsi.vidarr.server.remote.RemoteWorkflowEngineProvider;
 import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -607,7 +608,8 @@ public final class Main implements ServerConfig {
                           .timeout(Duration.ofMinutes(1))
                           .GET()
                           .build(),
-                      new JsonBodyHandler<>(MAPPER, AnalysisRecordDto.class));
+                      new JsonBodyHandler<>(
+                          MAPPER, new TypeReference<ProvenanceAnalysisRecord<ExternalKey>>() {}));
               if (response.statusCode() == HttpURLConnection.HTTP_OK) {
                 final var result = response.body().get();
                 return Optional.of(


### PR DESCRIPTION
This adds provenance DTOs used by Cerberus. This renames `AnalysisRecordDto` to
`ProvenanceAnalysisRecord` to make it consistent with the other analysis
provenance DTOs and parameterises the external key type. In the original
context, external keys are provided, but, in analysis provenance, external ids
are provided.