### PR TITLE
Handle null during start up recovery

### DIFF
--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseWorkflow.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseWorkflow.java
@@ -149,7 +149,9 @@ public class DatabaseWorkflow implements ActiveWorkflow<DatabaseOperation, DSLCo
         requestedInputIds,
         record.get(ACTIVE_WORKFLOW_RUN.PREFLIGHT_OKAY),
         record.get(ACTIVE_WORKFLOW_RUN.ENGINE_PHASE),
-        (ObjectNode) record.get(ACTIVE_WORKFLOW_RUN.REAL_INPUT),
+        record.get(ACTIVE_WORKFLOW_RUN.REAL_INPUT).isNull()
+            ? null
+            : (ObjectNode) record.get(ACTIVE_WORKFLOW_RUN.REAL_INPUT),
         liveness);
   }
 


### PR DESCRIPTION
If a workflow run hasn't started, the value stored in `real_input` will be JSON
`null`, which gets translated to `NullNode`, causing a cast exception. This
switches it for Java `null`.