### PR TITLE
Create consumable resource infrastructure

### DIFF
--- a/plugin-guide.md
+++ b/plugin-guide.md
@@ -30,6 +30,16 @@ expected to journal their current state to the database. The `WorkMonitor`
 provides methods to journal state to the database for crash recovery and to
 provide status information to users.
 
+# Consumable Resource
+Consumable resources implement
+`ca.on.oicr.gsi.vidarr.ConsumableResourceProvider` and
+`ca.on.oicr.gsi.vidarr.ConsumableResource`. These plugins are responsible for
+delaying workflow run execution until resources are available.
+
+The plugins can be associated with targets in the server configuration.
+Consumable resources _may_ request that submitters provide information or
+operate on the existence of a workflow run.
+
 # Input Provisioners
 Input provisioners implement `ca.on.oicr.gsi.vidarr.InputProvisionerProvider`
 and `ca.on.oicr.gsi.vidarr.InputProvisioner`. These plugins are responsible for

--- a/vidarr-cli/src/main/java/ca/on/oicr/gsi/vidarr/cli/TargetConfiguration.java
+++ b/vidarr-cli/src/main/java/ca/on/oicr/gsi/vidarr/cli/TargetConfiguration.java
@@ -123,6 +123,11 @@ public final class TargetConfiguration {
               .collect(Collectors.toList());
 
       @Override
+      public Stream<ConsumableResource> consumableResources() {
+        return Stream.empty();
+      }
+
+      @Override
       public WorkflowEngine engine() {
         return engine;
       }

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseProcessor.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseProcessor.java
@@ -771,11 +771,16 @@ public abstract class BaseProcessor<
     this.executor = executor;
   }
 
+  protected final ScheduledExecutorService executor() {
+    return executor;
+  }
+
   protected abstract ObjectMapper mapper();
 
   protected void recover(
       Target target, WorkflowDefinition definition, W workflow, List<PO> activeOperations) {
     switch (workflow.phase()) {
+      case WAITING_FOR_RESOURCES:
       case INITIALIZING:
         startTransaction(transaction -> start(target, definition, workflow, transaction));
         break;

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/MaxInFlightConsumableResource.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/MaxInFlightConsumableResource.java
@@ -1,0 +1,68 @@
+package ca.on.oicr.gsi.vidarr.core;
+
+import ca.on.oicr.gsi.Pair;
+import ca.on.oicr.gsi.vidarr.BasicType;
+import ca.on.oicr.gsi.vidarr.ConsumableResource;
+import ca.on.oicr.gsi.vidarr.ConsumableResourceProvider;
+import ca.on.oicr.gsi.vidarr.ConsumableResourceResponse;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class MaxInFlightConsumableResource implements ConsumableResource {
+  public static ConsumableResourceProvider provider() {
+    return new ConsumableResourceProvider() {
+      @Override
+      public ConsumableResource readConfiguration(String name, ObjectNode node) {
+        return new MaxInFlightConsumableResource(name, node.get("maximum").asInt(0));
+      }
+
+      @Override
+      public String type() {
+        return "max-in-flight";
+      }
+    };
+  }
+
+  private final String name;
+  private final int maximum;
+  private final Set<String> inFlight;
+
+  public MaxInFlightConsumableResource(String name, int maximum) {
+    this.name = name;
+    this.maximum = maximum;
+    inFlight = ConcurrentHashMap.newKeySet(maximum);
+  }
+
+  @Override
+  public Optional<Pair<String, BasicType>> inputFromUser() {
+    return Optional.empty();
+  }
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public void recover(String workflowName, String workflowVersion, String vidarrId) {
+    inFlight.add(vidarrId);
+  }
+
+  @Override
+  public void release(String workflowName, String workflowVersion, String vidarrId) {
+    inFlight.remove(vidarrId);
+  }
+
+  @Override
+  public ConsumableResourceResponse request(
+      String workflowName, String workflowVersion, String vidarrId, Optional<JsonNode> input) {
+    if (inFlight.size() <= maximum) {
+      return ConsumableResourceResponse.AVAILABLE;
+    } else {
+      return ConsumableResourceResponse.UNAVAILABLE;
+    }
+  }
+}

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/Phase.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/Phase.java
@@ -2,6 +2,7 @@ package ca.on.oicr.gsi.vidarr.core;
 
 /** The steps (phases) for running a workflow */
 public enum Phase {
+  WAITING_FOR_RESOURCES,
   INITIALIZING,
   PREFLIGHT,
   PROVISION_IN,

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/Target.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/Target.java
@@ -1,5 +1,6 @@
 package ca.on.oicr.gsi.vidarr.core;
 
+import ca.on.oicr.gsi.vidarr.ConsumableResource;
 import ca.on.oicr.gsi.vidarr.InputProvisionFormat;
 import ca.on.oicr.gsi.vidarr.InputProvisioner;
 import ca.on.oicr.gsi.vidarr.OutputProvisionFormat;
@@ -10,6 +11,9 @@ import java.util.stream.Stream;
 
 /** The workflow engine configuration for the processor to use */
 public interface Target {
+
+  /** All consumable resources */
+  Stream<ConsumableResource> consumableResources();
   /** The workflow engine plugin to use */
   WorkflowEngine engine();
 

--- a/vidarr-core/src/main/java/module-info.java
+++ b/vidarr-core/src/main/java/module-info.java
@@ -1,7 +1,9 @@
+import ca.on.oicr.gsi.vidarr.ConsumableResourceProvider;
 import ca.on.oicr.gsi.vidarr.InputProvisionerProvider;
 import ca.on.oicr.gsi.vidarr.OutputProvisionerProvider;
 import ca.on.oicr.gsi.vidarr.UnloaderProvider;
 import ca.on.oicr.gsi.vidarr.WorkflowEngineProvider;
+import ca.on.oicr.gsi.vidarr.core.MaxInFlightConsumableResource;
 import ca.on.oicr.gsi.vidarr.core.OneOfInputProvisioner;
 import ca.on.oicr.gsi.vidarr.core.OneOfOutputProvisioner;
 import ca.on.oicr.gsi.vidarr.core.RawInputProvisioner;
@@ -24,6 +26,8 @@ module ca.on.oicr.gsi.vidarr.core {
   uses UnloaderProvider;
   uses WorkflowEngineProvider;
 
+  provides ConsumableResourceProvider with
+      MaxInFlightConsumableResource;
   provides InputProvisionerProvider with
       OneOfInputProvisioner,
       RawInputProvisioner;

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/ConsumableResource.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/ConsumableResource.java
@@ -1,0 +1,49 @@
+package ca.on.oicr.gsi.vidarr;
+
+import ca.on.oicr.gsi.Pair;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Optional;
+
+/** A broker that can block workflows from starting by managing their resource footprints */
+public interface ConsumableResource {
+
+  /**
+   * To operate, this resource requires the submission request to include a parameter.
+   *
+   * @return the name of the parameter and the type required or an empty value if no input is
+   *     required.
+   */
+  Optional<Pair<String, BasicType>> inputFromUser();
+
+  /** The name provided during initialisation */
+  String name();
+  /**
+   * Indicate that Vidarr has restarted and it is reasserting an old claim.
+   *
+   * @param workflowName the name of the workflow
+   * @param workflowVersion the version of the workflow
+   * @param vidarrId the identifier of the workflow run
+   */
+  void recover(String workflowName, String workflowVersion, String vidarrId);
+
+  /**
+   * Indicate that the workflow is done with this resource
+   *
+   * @param workflowName the name of the workflow
+   * @param workflowVersion the version of the workflow
+   * @param vidarrId the identifier of the workflow run
+   */
+  void release(String workflowName, String workflowVersion, String vidarrId);
+
+  /**
+   * Request the resource
+   *
+   * @param workflowName the name of the workflow
+   * @param workflowVersion the version of the workflow
+   * @param vidarrId the identifier of the workflow run
+   * @param input the input requested from the submitter, if applicable and provided
+   * @return whether this resource is available
+   */
+  ConsumableResourceResponse request(
+      String workflowName, String workflowVersion, String vidarrId, Optional<JsonNode> input);
+}

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/ConsumableResourceProvider.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/ConsumableResourceProvider.java
@@ -1,0 +1,18 @@
+package ca.on.oicr.gsi.vidarr;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/** Reads JSON configuration and instantiates consumable resource appropriately */
+public interface ConsumableResourceProvider {
+  /**
+   * Prepare a consumable resource from a JSON configuration
+   *
+   * @param name the name that should be returned by {@link ConsumableResource#name()}
+   * @param node the JSON data
+   * @return the consumable resource
+   */
+  ConsumableResource readConfiguration(String name, ObjectNode node);
+
+  /** Get the name for this configuration in JSON files */
+  String type();
+}

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/ConsumableResourceResponse.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/ConsumableResourceResponse.java
@@ -1,0 +1,83 @@
+package ca.on.oicr.gsi.vidarr;
+
+/** The result from a request to access a consumable resource */
+public abstract class ConsumableResourceResponse {
+
+  /**
+   * Transform the result of a consumable resource response into another value
+   *
+   * @param <T> the type to convert to
+   */
+  public interface Visitor<T> {
+
+    /**
+     * Convert the successful acquisition of a response
+     *
+     * @return the transformed object
+     */
+    T available();
+
+    /**
+     * Convert an unsuccessful response
+     *
+     * @param message the error message for why the resource could not be allocated
+     * @return the transformed object
+     */
+    T error(String message);
+
+    /**
+     * Convert an unsuccessful but empty response
+     *
+     * @return the transformed object
+     */
+    T unavailable();
+  }
+
+  /**
+   * An indication that this resource is fine to allow the workflow to be run and, at the end of the
+   * workflow, the resources used do not need to be accounted for.
+   */
+  public static final ConsumableResourceResponse AVAILABLE =
+      new ConsumableResourceResponse() {
+        @Override
+        public <T> T apply(Visitor<T> visitor) {
+          return visitor.available();
+        }
+      };
+  /** A value that indicates the resource has insufficient capacity to fulfill the request. */
+  public static final ConsumableResourceResponse UNAVAILABLE =
+      new ConsumableResourceResponse() {
+        @Override
+        public <T> T apply(Visitor<T> visitor) {
+          return visitor.unavailable();
+        }
+      };
+  /**
+   * Create a new error response
+   *
+   * <p>An error occurs when the input request is invalid or the resource's state cannot be safely
+   * determined.
+   *
+   * @param message a message that should be reported to the user
+   * @return a result value that can be provided to the resource-accessor
+   */
+  public static ConsumableResourceResponse error(String message) {
+    return new ConsumableResourceResponse() {
+      @Override
+      public <T> T apply(Visitor<T> visitor) {
+        return visitor.error(message);
+      }
+    };
+  }
+
+  private ConsumableResourceResponse() {}
+
+  /**
+   * Convert this response into another value
+   *
+   * @param visitor the converter
+   * @param <T> the result type
+   * @return the value from conversion
+   */
+  public abstract <T> T apply(Visitor<T> visitor);
+}

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/InputProvisionerProvider.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/InputProvisionerProvider.java
@@ -9,7 +9,7 @@ public interface InputProvisionerProvider {
    * Prepare an input provisioner from a JSON configuration
    *
    * @param node the JSON data
-   * @return the workflow engine
+   * @return the input provisioner
    */
   InputProvisioner readConfiguration(ObjectNode node);
 

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/AddWorkflowRequest.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/AddWorkflowRequest.java
@@ -7,13 +7,8 @@ import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class AddWorkflowRequest {
-  private Map<String, Long> consumableResources = Collections.emptyMap();
   private Map<String, BasicType> labels = Collections.emptyMap();
   private int maxInFlight;
-
-  public Map<String, Long> getConsumableResources() {
-    return consumableResources;
-  }
 
   public Map<String, BasicType> getLabels() {
     return labels;
@@ -21,10 +16,6 @@ public class AddWorkflowRequest {
 
   public int getMaxInFlight() {
     return maxInFlight;
-  }
-
-  public void setConsumableResources(Map<String, Long> consumableResources) {
-    this.consumableResources = consumableResources;
   }
 
   public void setLabels(Map<String, BasicType> labels) {

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/SubmitWorkflowRequest.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/SubmitWorkflowRequest.java
@@ -11,7 +11,7 @@ import java.util.Set;
 public final class SubmitWorkflowRequest {
   private ObjectNode arguments;
   private int attempt;
-  private Map<String, Long> consumableResources;
+  private Map<String, JsonNode> consumableResources;
   private JsonNode engineParameters;
   private Set<ExternalKey> externalKeys;
   private ObjectNode labels;
@@ -51,7 +51,7 @@ public final class SubmitWorkflowRequest {
     return attempt;
   }
 
-  public Map<String, Long> getConsumableResources() {
+  public Map<String, JsonNode> getConsumableResources() {
     return consumableResources;
   }
 
@@ -111,7 +111,7 @@ public final class SubmitWorkflowRequest {
     this.attempt = attempt;
   }
 
-  public void setConsumableResources(Map<String, Long> consumableResources) {
+  public void setConsumableResources(Map<String, JsonNode> consumableResources) {
     this.consumableResources = consumableResources;
   }
 

--- a/vidarr-server/pom.xml
+++ b/vidarr-server/pom.xml
@@ -94,7 +94,7 @@
                     <port>${pg.port}:5432</port>
                   </ports>
                   <wait>
-                    <time>15000</time>
+                    <time>20000</time>
                   </wait>
                 </run>
               </image>

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/ConsumableResourceChecker.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/ConsumableResourceChecker.java
@@ -1,0 +1,124 @@
+package ca.on.oicr.gsi.vidarr.server;
+
+import static ca.on.oicr.gsi.vidarr.server.jooq.Tables.ACTIVE_WORKFLOW_RUN;
+
+import ca.on.oicr.gsi.vidarr.ConsumableResourceResponse.Visitor;
+import ca.on.oicr.gsi.vidarr.core.Target;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.zaxxer.hikari.HikariDataSource;
+import io.prometheus.client.Histogram;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+
+final class ConsumableResourceChecker implements Runnable {
+  private static final Histogram waitTime =
+      Histogram.build(
+              "vidarr_consumable_resource_wait_time",
+              "A histogram of the waiting time, in seconds, of how long a workflow run waited for"
+                  + " resources.")
+          .buckets(60, 300, 600, 3600, 7200, 21600, 43200, 86400, 129600, 172800)
+          .labelNames("workflow")
+          .register();
+
+  private final Map<String, JsonNode> consumableResources;
+  private final HikariDataSource dataSource;
+  private final int dbId;
+  private final ScheduledExecutorService executor;
+  private final Runnable next;
+  private final Instant startTime = Instant.now();
+  private final Target target;
+  private final String vidarrId;
+  private final String workflow;
+  private final String workflowVersion;
+
+  public ConsumableResourceChecker(
+      Target target,
+      HikariDataSource dataSource,
+      ScheduledExecutorService executor,
+      int dbId,
+      String workflow,
+      String workflowVersion,
+      String vidarrId,
+      Map<String, JsonNode> consumableResources,
+      Runnable next) {
+    this.target = target;
+    this.dataSource = dataSource;
+    this.executor = executor;
+    this.dbId = dbId;
+    this.workflow = workflow;
+    this.workflowVersion = workflowVersion;
+    this.vidarrId = vidarrId;
+    this.consumableResources = consumableResources;
+    this.next = next;
+  }
+
+  @Override
+  public void run() {
+    var i = 0;
+    final var resourceBrokers = target.consumableResources().collect(Collectors.toList());
+    for (i = 0; i < resourceBrokers.size(); i++) {
+      final var broker = resourceBrokers.get(i);
+      final var error =
+          broker
+              .request(
+                  workflow,
+                  workflowVersion,
+                  vidarrId,
+                  broker.inputFromUser().map(def -> consumableResources.get(def.first())))
+              .apply(
+                  new Visitor<Optional<String>>() {
+                    @Override
+                    public Optional<String> available() {
+                      return Optional.empty();
+                    }
+
+                    @Override
+                    public Optional<String> error(String message) {
+                      return Optional.of(message);
+                    }
+
+                    @Override
+                    public Optional<String> unavailable() {
+                      return Optional.of(
+                          String.format("Resource %s is not available", broker.name()));
+                    }
+                  });
+      if (error.isPresent()) {
+        updateBlockedResource(error.get());
+        // Skip the last one, because it already failed, so we don't have to release any resources.
+        while (--i >= 0) {
+          resourceBrokers.get(i).release(workflow, workflowVersion, vidarrId);
+        }
+        executor.schedule(this, 5, TimeUnit.MINUTES);
+        return;
+      }
+    }
+    updateBlockedResource(null);
+    waitTime.labels(workflow).observe(Duration.between(startTime, Instant.now()).toSeconds());
+    next.run();
+  }
+
+  private void updateBlockedResource(String error) {
+    try (final var connection = dataSource.getConnection()) {
+      DSL.using(connection, SQLDialect.POSTGRES)
+          .transaction(
+              configuration ->
+                  DSL.using(configuration)
+                      .update(ACTIVE_WORKFLOW_RUN)
+                      .set(ACTIVE_WORKFLOW_RUN.WAITING_RESOURCE, error)
+                      .where(ACTIVE_WORKFLOW_RUN.ID.eq(dbId))
+                      .execute());
+
+    } catch (SQLException ex) {
+      ex.printStackTrace();
+    }
+  }
+}

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/MaxInFlightByWorkflow.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/MaxInFlightByWorkflow.java
@@ -1,0 +1,82 @@
+package ca.on.oicr.gsi.vidarr.server;
+
+import ca.on.oicr.gsi.Pair;
+import ca.on.oicr.gsi.vidarr.BasicType;
+import ca.on.oicr.gsi.vidarr.ConsumableResource;
+import ca.on.oicr.gsi.vidarr.ConsumableResourceResponse;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.prometheus.client.Gauge;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+final class MaxInFlightByWorkflow implements ConsumableResource {
+  private static final class MaxState {
+    private int maximum;
+    private final Set<String> running = ConcurrentHashMap.newKeySet();
+  }
+
+  private static final Gauge currentInFlightCount =
+      Gauge.build(
+              "vidarr_in_flight_per_workflow_current",
+              "The current number of workflows are running.")
+          .labelNames("workflow")
+          .register();
+  private static final Gauge maxInFlightCount =
+      Gauge.build(
+              "vidarr_in_flight_per_workflow_max",
+              "The maximum number of workflows that can be run simultaneously.")
+          .labelNames("workflow")
+          .register();
+  private final Map<String, MaxState> workflows = new ConcurrentHashMap<>();
+
+  @Override
+  public Optional<Pair<String, BasicType>> inputFromUser() {
+    return Optional.empty();
+  }
+
+  @Override
+  public String name() {
+    return null;
+  }
+
+  @Override
+  public void recover(String workflowName, String workflowVersion, String vidarrId) {
+    workflows.computeIfAbsent(workflowName, k -> new MaxState()).running.add(vidarrId);
+  }
+
+  @Override
+  public void release(String workflowName, String workflowVersion, String vidarrId) {
+    final var state = workflows.get(workflowName);
+    if (state != null) {
+      state.running.remove(vidarrId);
+      currentInFlightCount.labels(workflowName).set(state.running.size());
+    }
+  }
+
+  @Override
+  public ConsumableResourceResponse request(
+      String workflowName, String workflowVersion, String vidarrId, Optional<JsonNode> input) {
+    final var state = workflows.get(workflowName);
+    if (state == null) {
+      return ConsumableResourceResponse.error(
+          "Internal Vidarr error: max in flight has not been configured despite being in the"
+              + " database.");
+    } else {
+      if (state.maximum > state.running.size()) {
+        state.running.add(vidarrId);
+        currentInFlightCount.labels(workflowName).set(state.running.size());
+        return ConsumableResourceResponse.AVAILABLE;
+      } else {
+        return ConsumableResourceResponse.error(
+            String.format("The maximum number of %s workflows has been reached.", workflowName));
+      }
+    }
+  }
+
+  public void set(String workflowName, int maxInFlight) {
+    maxInFlightCount.labels(workflowName).set(maxInFlight);
+    workflows.computeIfAbsent(workflowName, k -> new MaxState()).maximum = maxInFlight;
+  }
+}

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/dto/ServerConfiguration.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/dto/ServerConfiguration.java
@@ -2,10 +2,12 @@ package ca.on.oicr.gsi.vidarr.server.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Collections;
 import java.util.Map;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public final class ServerConfiguration {
+  private Map<String, ObjectNode> consumableResources = Collections.emptyMap();
   private String dbHost;
   private String dbName;
   private String dbPass;
@@ -20,6 +22,10 @@ public final class ServerConfiguration {
   private Map<String, TargetConfiguration> targets;
   private String url;
   private Map<String, ObjectNode> workflowEngines;
+
+  public Map<String, ObjectNode> getConsumableResources() {
+    return consumableResources;
+  }
 
   public String getDbHost() {
     return dbHost;
@@ -75,6 +81,10 @@ public final class ServerConfiguration {
 
   public Map<String, ObjectNode> getWorkflowEngines() {
     return workflowEngines;
+  }
+
+  public void setConsumableResources(Map<String, ObjectNode> consumableResources) {
+    this.consumableResources = consumableResources;
   }
 
   public void setDbHost(String dbHost) {

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/dto/TargetConfiguration.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/dto/TargetConfiguration.java
@@ -5,10 +5,15 @@ import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TargetConfiguration {
+  private List<String> consumableResources;
   private List<String> inputProvisioners;
   private List<String> outputProvisioners;
   private List<String> runtimeProvisioners;
   private String workflowEngine;
+
+  public List<String> getConsumableResources() {
+    return consumableResources;
+  }
 
   public List<String> getInputProvisioners() {
     return inputProvisioners;
@@ -24,6 +29,10 @@ public class TargetConfiguration {
 
   public String getWorkflowEngine() {
     return workflowEngine;
+  }
+
+  public void setConsumableResources(List<String> consumableResources) {
+    this.consumableResources = consumableResources;
   }
 
   public void setInputProvisioners(List<String> inputProvisioners) {

--- a/vidarr-server/src/main/java/module-info.java
+++ b/vidarr-server/src/main/java/module-info.java
@@ -1,3 +1,4 @@
+import ca.on.oicr.gsi.vidarr.ConsumableResourceProvider;
 import ca.on.oicr.gsi.vidarr.InputProvisionerProvider;
 import ca.on.oicr.gsi.vidarr.OutputProvisionerProvider;
 import ca.on.oicr.gsi.vidarr.RuntimeProvisionerProvider;
@@ -36,6 +37,7 @@ module ca.on.oicr.gsi.vidarr.server {
       org.jooq;
   opens db.migration;
 
+  uses ConsumableResourceProvider;
   uses InputProvisionerProvider;
   uses OutputProvisionerProvider;
   uses RuntimeProvisionerProvider;

--- a/vidarr-server/src/main/resources/db/migration/V0001__initial.sql
+++ b/vidarr-server/src/main/resources/db/migration/V0001__initial.sql
@@ -65,6 +65,7 @@ CREATE TABLE public.active_workflow_run (
     attempt integer NOT NULL DEFAULT 0,
     cleanup_state jsonb,
     completed timestamp with time zone,
+    consumable_resources jsonb NOT NULL,
     created timestamp with time zone DEFAULT (now())::timestamp(0) with time zone NOT NULL,
     engine_phase integer,
     external_input_ids_handled boolean NOT NULL,
@@ -73,6 +74,7 @@ CREATE TABLE public.active_workflow_run (
     real_input jsonb,
     started timestamp with time zone,
     target character varying(255),
+    waiting_resource character varying(255),
     workflow_run_url character varying
 );
 
@@ -217,7 +219,6 @@ ALTER SEQUENCE public.external_id_version_id_seq OWNED BY public.external_id_ver
 
 CREATE TABLE public.workflow (
     id integer NOT NULL,
-    consumable_resources jsonb,
     created timestamp with time zone DEFAULT (now())::timestamp(0) with time zone NOT NULL,
     is_active boolean NOT NULL,
     labels jsonb,


### PR DESCRIPTION
This creates a way to limit workflows from starting by tracking resources. This
is planned more as a future project, so this adds an interface and basic
implementations for tracking max-in-flight on a per-workflow and per-target
level.