### PR TITLE
Add DTOs for `/api/targets` and `/api/workflows`

### DIFF
--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/TargetDeclaration.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/TargetDeclaration.java
@@ -1,0 +1,58 @@
+package ca.on.oicr.gsi.vidarr.api;
+
+import ca.on.oicr.gsi.vidarr.InputProvisionFormat;
+import ca.on.oicr.gsi.vidarr.OutputProvisionFormat;
+import ca.on.oicr.gsi.vidarr.BasicType;
+import ca.on.oicr.gsi.vidarr.WorkflowLanguage;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public final class TargetDeclaration {
+  private Map<String, BasicType> consumableResources = Collections.emptyMap();
+  private BasicType engineParameters;
+  private Map<InputProvisionFormat, BasicType> inputProvisioners;
+  private List<WorkflowLanguage> language;
+  private Map<OutputProvisionFormat, BasicType> outputProvisioners;
+
+  public Map<String, BasicType> getConsumableResources() {
+    return consumableResources;
+  }
+
+  public BasicType getEngineParameters() {
+    return engineParameters;
+  }
+
+  public Map<InputProvisionFormat, BasicType> getInputProvisioners() {
+    return inputProvisioners;
+  }
+
+  public List<WorkflowLanguage> getLanguage() {
+    return language;
+  }
+
+  public Map<OutputProvisionFormat, BasicType> getOutputProvisioners() {
+    return outputProvisioners;
+  }
+
+  public void setConsumableResources(
+      Map<String, BasicType> consumableResources) {
+    this.consumableResources = consumableResources;
+  }
+
+  public void setEngineParameters(BasicType engineParameters) {
+    this.engineParameters = engineParameters;
+  }
+
+  public void setInputProvisioners(Map<InputProvisionFormat, BasicType> inputProvisioners) {
+    this.inputProvisioners = inputProvisioners;
+  }
+
+  public void setLanguage(List<WorkflowLanguage> language) {
+    this.language = language;
+  }
+
+  public void setOutputProvisioners(Map<OutputProvisionFormat, BasicType> outputProvisioners) {
+    this.outputProvisioners = outputProvisioners;
+  }
+}

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/WorkflowDeclaration.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/WorkflowDeclaration.java
@@ -1,0 +1,64 @@
+package ca.on.oicr.gsi.vidarr.api;
+
+import ca.on.oicr.gsi.vidarr.InputType;
+import ca.on.oicr.gsi.vidarr.OutputType;
+import ca.on.oicr.gsi.vidarr.BasicType;
+import ca.on.oicr.gsi.vidarr.WorkflowLanguage;
+import java.util.Map;
+
+public final class WorkflowDeclaration {
+  private Map<String, BasicType> labels;
+  private WorkflowLanguage language;
+  private Map<String, OutputType> metadata;
+  private String name;
+  private Map<String, InputType> parameters;
+  private String version;
+
+  public Map<String, BasicType> getLabels() {
+    return labels;
+  }
+
+  public WorkflowLanguage getLanguage() {
+    return language;
+  }
+
+  public Map<String, OutputType> getMetadata() {
+    return metadata;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Map<String, InputType> getParameters() {
+    return parameters;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setLabels(Map<String, BasicType> labels) {
+    this.labels = labels;
+  }
+
+  public void setLanguage(WorkflowLanguage language) {
+    this.language = language;
+  }
+
+  public void setMetadata(Map<String, OutputType> metadata) {
+    this.metadata = metadata;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public void setParameters(Map<String, InputType> parameters) {
+    this.parameters = parameters;
+  }
+
+  public void setVersion(String version) {
+    this.version = version;
+  }
+}


### PR DESCRIPTION
These are used by the Shesmu plugin for decoding the results of those
endpoints.

These are matched to the format in #24.