### PR TITLE
Fix bugs in input ID handling and hashing

### DIFF
--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseProcessor.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseProcessor.java
@@ -702,11 +702,7 @@ public abstract class BaseProcessor<
       ObjectMapper mapper, WorkflowDefinition definition, JsonNode arguments) {
     return definition
         .parameters()
-        .flatMap(
-            p ->
-                arguments.has(p.name())
-                    ? p.type().apply(new ExtractInputVidarrIds(mapper, arguments.get(p.name())))
-                    : Stream.of("Missing input parameter: " + p.name()))
+        .flatMap(p -> p.type().apply(new ExtractInputVidarrIds(mapper, arguments.get(p.name()))))
         .distinct();
   }
 

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
@@ -459,6 +459,7 @@ public abstract class DatabaseBackedProcessor
                 arguments.has(p.name())
                     ? Stream.empty()
                     : p.type().apply(new ExtractInputVidarrIds(MAPPER, arguments.get(p.name()))))
+        .map(id -> BaseProcessor.ANALYSIS_RECORD_ID.matcher(id).group("hash"))
         .collect(Collectors.toCollection(TreeSet::new));
   }
 


### PR DESCRIPTION
This fixes several bugs related to input IDs. When a workflow is run, the input
can be the output of an existing workflow specified as a URL of the form
`vidarr:`_instance_`/file/`_hash_. The input validator was not checking that
the IDs were of the correct format. The URL `vidarr:`_instance_`/url/`_hash_ is
valid, but cannot be used for input files.

The extractor would incorrectly mix an error message with the IDs. This error
case should already have been handled much earlier in validation, so the error
handler can be removed.

Finally, the input IDs are baked into the workflow run ID, but only the _hash_
portion of the URL should be included. The logic is something like this:

1. A workflow run competes on a `prod` server and has hash `01234`.
2. This data is available through file provenance as `vidarr:prod/file/01234`.
3. A workflow run competes on a `dev` server and has hash `78910`.
4. This data is available through file provenance as `vidarr:prod/file/78910`.
5. A workflow run on a `dev` server that consumes both files. The workflow run ID
   incorporates `01234` and `078910`.
6. All workflow runs are unloaded from `dev` and loaded on `prod`. The workflow
   run ID should not change.

The only way for the workflow run ID to not change is for *only* the file's ID
hash to used as the input identifier. The instance name is required to resolve
the file, but should not be used in calculating the workflow run hash.