### PR TITLE
Change Cromwell engine parameter type parsing

### DIFF
--- a/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/CromwellWorkflowEngine.java
+++ b/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/CromwellWorkflowEngine.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.vidarr.cromwell;
 import ca.on.oicr.gsi.Pair;
 import ca.on.oicr.gsi.status.SectionRenderer;
 import ca.on.oicr.gsi.vidarr.*;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -16,6 +17,7 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -33,9 +35,15 @@ public final class CromwellWorkflowEngine
       public WorkflowEngine readConfiguration(ObjectNode node) {
         var engineParameters = Optional.<BasicType>empty();
         if (node.has("engineParameters")) {
-          engineParameters =
-              Optional.ofNullable(
-                  MAPPER.convertValue(node.get("engineParameters"), BasicType.class));
+          final var fields =
+              MAPPER.convertValue(
+                  node.get("engineParameters"), new TypeReference<Map<String, BasicType>>() {});
+          if (!fields.isEmpty()) {
+            engineParameters =
+                Optional.of(
+                    BasicType.object(
+                        fields.entrySet().stream().map(e -> new Pair<>(e.getKey(), e.getValue()))));
+          }
         }
         return new CromwellWorkflowEngine(node.get("url").asText(), engineParameters);
       }


### PR DESCRIPTION
Cromwell requires that the WDL options be a JSON object and the manual has this
as a map of names to types. The parser did not parse this as described in the
manual and would allow non-object types. This forces conversion to match the
manual and always provide an object.