### PR TITLE
Fix accessory workflow file hash

### DIFF
--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
@@ -769,7 +769,7 @@ public final class Main implements ServerConfig {
         final var accessoryHash =
             BaseProcessor.hexDigits(
                 MessageDigest.getInstance("SHA-256")
-                    .digest(request.getWorkflow().getBytes(StandardCharsets.UTF_8)));
+                    .digest(accessory.getValue().getBytes(StandardCharsets.UTF_8)));
         versionDigest.update(new byte[] {0});
         versionDigest.update(accessory.getKey().getBytes(StandardCharsets.UTF_8));
         versionDigest.update(new byte[] {0});


### PR DESCRIPTION
This was calculating the has on the main workflow file rather than the correct
accessory (supplemental) file included.