### PR TITLE
Add operation's phase to database

### DIFF
--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/OperationStatusResponse.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/OperationStatusResponse.java
@@ -7,12 +7,17 @@ import com.fasterxml.jackson.databind.JsonNode;
 public class OperationStatusResponse {
 
   private JsonNode debugInformation;
+  private String enginePhase;
   private JsonNode recoveryState;
   private String status;
   private String type;
 
   public JsonNode getDebugInformation() {
     return debugInformation;
+  }
+
+  public String getEnginePhase() {
+    return enginePhase;
   }
 
   public JsonNode getRecoveryState() {
@@ -29,6 +34,10 @@ public class OperationStatusResponse {
 
   public void setDebugInformation(JsonNode debugInformation) {
     this.debugInformation = debugInformation;
+  }
+
+  public void setEnginePhase(String enginePhase) {
+    this.enginePhase = enginePhase;
   }
 
   public void setRecoveryState(JsonNode recoveryState) {

--- a/vidarr-server/pom.xml
+++ b/vidarr-server/pom.xml
@@ -176,7 +176,7 @@
                         <from>i -&gt; Phase.values()[i]</from>
                         <to>Phase::ordinal</to>
                       </lambdaConverter>
-                      <expression>public\.active_workflow_run\.engine_phase</expression>
+                      <expression>.*\.engine_phase</expression>
                       <types>.*</types>
                     </forcedType>
                     <forcedType>

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseOperation.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseOperation.java
@@ -17,6 +17,7 @@ public class DatabaseOperation implements ActiveOperation<DSLContext> {
   public static Optional<DatabaseOperation> create(
       DSLContext dsl,
       int workflowId,
+      Phase phase,
       String type,
       JsonNode recoveryState,
       int attempt,
@@ -25,6 +26,7 @@ public class DatabaseOperation implements ActiveOperation<DSLContext> {
     return dsl.insertInto(ACTIVE_OPERATION)
         .set(ACTIVE_OPERATION.TYPE, type)
         .set(ACTIVE_OPERATION.STATUS, OperationStatus.INITIALIZING)
+        .set(ACTIVE_OPERATION.ENGINE_PHASE, phase)
         .set(ACTIVE_OPERATION.WORKFLOW_RUN_ID, workflowId)
         .set(ACTIVE_OPERATION.ATTEMPT, attempt)
         .set(ACTIVE_OPERATION.RECOVERY_STATE, recoveryState)

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseWorkflow.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseWorkflow.java
@@ -428,7 +428,14 @@ public class DatabaseWorkflow implements ActiveWorkflow<DatabaseOperation, DSLCo
           .map(
               state ->
                   DatabaseOperation.create(
-                          transaction, id, state.first(), state.second(), attempt, liveness, this)
+                          transaction,
+                          id,
+                          phase,
+                          state.first(),
+                          state.second(),
+                          attempt,
+                          liveness,
+                          this)
                       .orElseThrow())
           .collect(Collectors.toList());
     } else {

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
@@ -197,6 +197,14 @@ public final class Main implements ServerConfig {
                         DSL.jsonArrayAgg(
                             DSL.jsonObject(
                                 DSL.jsonEntry("attempt", ACTIVE_OPERATION.ATTEMPT),
+                                DSL.jsonEntry(
+                                    "enginePhase",
+                                    DSL.case_(ACTIVE_OPERATION.ENGINE_PHASE)
+                                        .mapValues(
+                                            Stream.of(Phase.values())
+                                                .collect(
+                                                    Collectors.toMap(
+                                                        Function.identity(), Phase::name)))),
                                 DSL.jsonEntry("recoveryState", ACTIVE_OPERATION.RECOVERY_STATE),
                                 DSL.jsonEntry("debugInformation", ACTIVE_OPERATION.DEBUG_INFO),
                                 DSL.jsonEntry("status", ACTIVE_OPERATION.STATUS),

--- a/vidarr-server/src/main/resources/db/migration/V0002__operation_phase.sql
+++ b/vidarr-server/src/main/resources/db/migration/V0002__operation_phase.sql
@@ -1,0 +1,2 @@
+
+ALTER TABLE active_operation ADD COLUMN engine_phase integer NOT NULL DEFAULT 0;


### PR DESCRIPTION
Vidarr never needs to know what phase an operation is part of, but humans do.
This copies the phase information into the active operation table upon creation
for the purpose of showing it in the debugging output.