### PR TITLE
Add `equals` and `hashCode` that ignore attempt

### DIFF
--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/SubmitWorkflowRequest.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/SubmitWorkflowRequest.java
@@ -30,8 +30,11 @@ public final class SubmitWorkflowRequest {
       return false;
     }
     SubmitWorkflowRequest that = (SubmitWorkflowRequest) o;
-    return attempt == that.attempt
-        && Objects.equals(arguments, that.arguments)
+    return attempt == that.attempt && equalsIgnoreAttempt(that);
+  }
+
+  public boolean equalsIgnoreAttempt(SubmitWorkflowRequest that) {
+    return Objects.equals(arguments, that.arguments)
         && Objects.equals(consumableResources, that.consumableResources)
         && Objects.equals(engineParameters, that.engineParameters)
         && Objects.equals(externalKeys, that.externalKeys)
@@ -89,9 +92,12 @@ public final class SubmitWorkflowRequest {
 
   @Override
   public int hashCode() {
+    return hashCodeIgnoreAttempt() * 31 + Integer.hashCode(attempt);
+  }
+
+  public int hashCodeIgnoreAttempt() {
     return Objects.hash(
         arguments,
-        attempt,
         consumableResources,
         engineParameters,
         externalKeys,


### PR DESCRIPTION
Shesmu uses the `equals` and `hashCode` methods to decide if two submission
requests are equivalent. However, it allows the user to increase the attempt
number and this doesn't really matter for equality. This adds a second pair of
methods to exclude the attempt number, i n the vein of
`String.equalsIgnoreCase`.