### PR TITLE
Allow reattempting unstarted workflows

### DIFF
--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
@@ -156,7 +156,7 @@ public abstract class DatabaseBackedProcessor
           .and(
               ACTIVE_WORKFLOW_RUN
                   .ENGINE_PHASE
-                  .eq(Phase.FAILED)
+                  .in(Phase.FAILED, Phase.WAITING_FOR_RESOURCES)
                   .or(
                       DSL.exists(
                           DSL.select()
@@ -589,6 +589,7 @@ public abstract class DatabaseBackedProcessor
             dataSource,
             executor(),
             dbWorkflow.dbId(),
+            liveness(dbWorkflow.dbId()),
             name,
             version,
             candidateIds.get(0),
@@ -700,6 +701,7 @@ public abstract class DatabaseBackedProcessor
                                                 dataSource,
                                                 executor(),
                                                 record.get(ACTIVE_WORKFLOW_RUN.ID),
+                                                liveness(record.get(ACTIVE_WORKFLOW_RUN.ID)),
                                                 record.get(WORKFLOW.NAME),
                                                 record.get(WORKFLOW_VERSION.VERSION),
                                                 record.get(WORKFLOW_RUN.HASH_ID),


### PR DESCRIPTION
Currently, a workflow has to be failed to allow a reattempt by the user.
However, if a workflow is waiting for resources, it also makes sense to allow
it be reattempted or deleted since it could be configured in a broken way where
it will never reach a failed state. This extends the existing reattempt checks
to include the `WAITING_FOR_RESOURCES` state and to stop attempting resource
checks if the workflow has been killed.