### PR TITLE
Include attempt in operation DTO

### DIFF
--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/OperationStatusResponse.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/OperationStatusResponse.java
@@ -6,11 +6,16 @@ import com.fasterxml.jackson.databind.JsonNode;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class OperationStatusResponse {
 
+  private int attempt;
   private JsonNode debugInformation;
   private String enginePhase;
   private JsonNode recoveryState;
   private String status;
   private String type;
+
+  public int getAttempt() {
+    return attempt;
+  }
 
   public JsonNode getDebugInformation() {
     return debugInformation;
@@ -30,6 +35,10 @@ public class OperationStatusResponse {
 
   public String getType() {
     return type;
+  }
+
+  public void setAttempt(int attempt) {
+    this.attempt = attempt;
   }
 
   public void setDebugInformation(JsonNode debugInformation) {


### PR DESCRIPTION
The attempt property is already output by the `/api/status/` endpoint. This
adds the missing property to the DTO.