### PR TITLE
Add max-in-flight endpoint to the Vidarr server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .idea
 target
 vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/jooq/
+*~

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ tracked without modifying existing workflows.
 - [Plugin Developer's Guide](plugin-guide.md)
 - [Understanding the Vidarr Type System](types.md)
 - [Vidarr Identifiers](identifiers.md)
+- [Vidarr Code Style](code-style.md)
 
 Current plugins:
 

--- a/admin-guide.md
+++ b/admin-guide.md
@@ -7,6 +7,8 @@ Running a Vidarr instance involves a few separate roles:
 
 This guide is broken down by these roles, but they may overlap to some degree.
 
+See [Vidarr Code Style](code-style.md) for preferred code formatting.
+
 ## System Operations Guide
 Running a Vidarr instance requires:
 

--- a/code-style.md
+++ b/code-style.md
@@ -1,0 +1,12 @@
+# Vidarr code style
+
+The preferred coding style for Vidarr and Shesmu is in [vidarr-intellij-style.xml](vidarr-intellij-style.xml).
+
+To import this style to the [IntelliJ IDE](https://www.jetbrains.com/help/idea/installation-guide.html):
+- Go to `File -> Settings`
+- Click the small gear icon next to the `Code Style` dropdown
+- Select `Import Scheme -> IntelliJ IDEA Code Style XML` and browse to the desired file
+- Click `OK` to import `Shesmu Style`
+- Click `OK` in the main `Settings` dialog
+
+Existing code can be reformatted by setting up IntelliJ as above, opening the source file, and selecting `Code -> Rearrange Code`.

--- a/plugin-guide.md
+++ b/plugin-guide.md
@@ -30,6 +30,8 @@ expected to journal their current state to the database. The `WorkMonitor`
 provides methods to journal state to the database for crash recovery and to
 provide status information to users.
 
+See [Vidarr Code Style](code-style.md) for preferred code formatting.
+
 # Consumable Resource
 Consumable resources implement
 `ca.on.oicr.gsi.vidarr.ConsumableResourceProvider` and

--- a/vidarr-intellij-style.xml
+++ b/vidarr-intellij-style.xml
@@ -1,0 +1,239 @@
+<code_scheme name="Shesmu Style" version="173">
+  <option name="OTHER_INDENT_OPTIONS">
+    <value>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="2" />
+    </value>
+  </option>
+  <option name="RIGHT_MARGIN" value="100" />
+  <JSCodeStyleSettings>
+    <option name="INDENT_CHAINED_CALLS" value="false" />
+  </JSCodeStyleSettings>
+  <JavaCodeStyleSettings>
+    <option name="INSERT_INNER_CLASS_IMPORTS" value="true" />
+    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+    <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
+      <value />
+    </option>
+    <option name="IMPORT_LAYOUT_TABLE">
+      <value>
+        <package name="" withSubpackages="true" static="true" />
+        <emptyLine />
+        <package name="" withSubpackages="true" static="false" />
+      </value>
+    </option>
+  </JavaCodeStyleSettings>
+  <XML>
+    <option name="XML_ALIGN_ATTRIBUTES" value="false" />
+    <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
+  </XML>
+  <codeStyleSettings language="JAVA">
+    <option name="KEEP_CONTROL_STATEMENT_IN_ONE_LINE" value="false" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+    <option name="ALIGN_MULTILINE_RESOURCES" value="false" />
+    <option name="ALIGN_MULTILINE_FOR" value="false" />
+    <option name="CALL_PARAMETERS_WRAP" value="1" />
+    <option name="METHOD_PARAMETERS_WRAP" value="1" />
+    <option name="EXTENDS_LIST_WRAP" value="1" />
+    <option name="THROWS_KEYWORD_WRAP" value="1" />
+    <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
+    <option name="BINARY_OPERATION_WRAP" value="1" />
+    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+    <option name="TERNARY_OPERATION_WRAP" value="1" />
+    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+    <option name="FOR_STATEMENT_WRAP" value="1" />
+    <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+    <option name="WRAP_COMMENTS" value="true" />
+    <option name="IF_BRACE_FORCE" value="3" />
+    <option name="DOWHILE_BRACE_FORCE" value="3" />
+    <option name="WHILE_BRACE_FORCE" value="3" />
+    <option name="FOR_BRACE_FORCE" value="3" />
+    <indentOptions>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="2" />
+    </indentOptions>
+    <arrangement>
+      <groups />
+      <rules>
+        <section>
+          <rule>
+            <match>
+              <ENUM>true</ENUM>
+            </match>
+            <order>BY_NAME</order>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <INTERFACE>true</INTERFACE>
+            </match>
+            <order>BY_NAME</order>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <CLASS>true</CLASS>
+            </match>
+            <order>BY_NAME</order>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <FIELD>true</FIELD>
+                <STATIC>true</STATIC>
+              </AND>
+            </match>
+            <order>BY_NAME</order>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <INITIALIZER_BLOCK>true</INITIALIZER_BLOCK>
+                <STATIC>true</STATIC>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <METHOD>true</METHOD>
+                <STATIC>true</STATIC>
+              </AND>
+            </match>
+            <order>BY_NAME</order>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <FIELD>true</FIELD>
+            </match>
+            <order>BY_NAME</order>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <INITIALIZER_BLOCK>true</INITIALIZER_BLOCK>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <CONSTRUCTOR>true</CONSTRUCTOR>
+            </match>
+            <order>BY_NAME</order>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <METHOD>true</METHOD>
+            </match>
+            <order>BY_NAME</order>
+          </rule>
+        </section>
+      </rules>
+    </arrangement>
+  </codeStyleSettings>
+  <codeStyleSettings language="JSON">
+    <indentOptions>
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      <option name="TAB_SIZE" value="2" />
+    </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="JavaScript">
+    <option name="RIGHT_MARGIN" value="80" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+    <option name="ALIGN_MULTILINE_FOR" value="false" />
+    <option name="CALL_PARAMETERS_WRAP" value="1" />
+    <option name="METHOD_PARAMETERS_WRAP" value="1" />
+    <option name="BINARY_OPERATION_WRAP" value="1" />
+    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+    <option name="TERNARY_OPERATION_WRAP" value="1" />
+    <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+    <option name="FOR_STATEMENT_WRAP" value="1" />
+    <option name="ARRAY_INITIALIZER_WRAP" value="1" />
+    <option name="IF_BRACE_FORCE" value="3" />
+    <option name="DOWHILE_BRACE_FORCE" value="3" />
+    <option name="WHILE_BRACE_FORCE" value="3" />
+    <option name="FOR_BRACE_FORCE" value="3" />
+    <option name="PARENT_SETTINGS_INSTALLED" value="true" />
+    <indentOptions>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="TAB_SIZE" value="2" />
+    </indentOptions>
+  </codeStyleSettings>
+  <codeStyleSettings language="XML">
+    <indentOptions>
+      <option name="INDENT_SIZE" value="2" />
+      <option name="CONTINUATION_INDENT_SIZE" value="2" />
+      <option name="TAB_SIZE" value="2" />
+    </indentOptions>
+    <arrangement>
+      <rules>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <NAME>xmlns:.*</NAME>
+                <XML_ATTRIBUTE />
+                <XML_NAMESPACE>^$</XML_NAMESPACE>
+              </AND>
+            </match>
+            <order>BY_NAME</order>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <NAME>style</NAME>
+                <XML_ATTRIBUTE />
+                <XML_NAMESPACE>^$</XML_NAMESPACE>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <NAME>.*</NAME>
+                <XML_ATTRIBUTE />
+                <XML_NAMESPACE>^$</XML_NAMESPACE>
+              </AND>
+            </match>
+            <order>BY_NAME</order>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <NAME>.*</NAME>
+                <XML_NAMESPACE>.*</XML_NAMESPACE>
+              </AND>
+            </match>
+            <order>BY_NAME</order>
+          </rule>
+        </section>
+      </rules>
+    </arrangement>
+  </codeStyleSettings>
+</code_scheme>

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/InFlightCountsByWorkflow.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/InFlightCountsByWorkflow.java
@@ -1,0 +1,32 @@
+package ca.on.oicr.gsi.vidarr.api;
+
+import ca.on.oicr.gsi.Pair;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Class to record current and maximum inflight counts by workflow
+ */
+public class InFlightCountsByWorkflow {
+
+  private Map<String, Pair<Integer, Integer>> counts = new ConcurrentHashMap<>();
+
+  public void add(String workflow, Integer current, Integer max) {
+    Pair values = new Pair(current, max);
+    counts.put(workflow, values);
+  }
+
+  public int getCurrent(String workflow) {
+    return counts.get(workflow).first();
+  }
+
+  public int getMax(String workflow) {
+    return counts.get(workflow).second();
+  }
+
+  public Set<String> getWorkflows() {
+    return counts.keySet();
+  }
+
+}

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
@@ -11,6 +11,7 @@ import ca.on.oicr.gsi.vidarr.api.AddWorkflowVersionRequest;
 import ca.on.oicr.gsi.vidarr.api.AnalysisOutputType;
 import ca.on.oicr.gsi.vidarr.api.AnalysisProvenanceRequest;
 import ca.on.oicr.gsi.vidarr.api.ExternalKey;
+import ca.on.oicr.gsi.vidarr.api.InFlightCountsByWorkflow;
 import ca.on.oicr.gsi.vidarr.api.ProvenanceAnalysisRecord;
 import ca.on.oicr.gsi.vidarr.api.SubmitMode;
 import ca.on.oicr.gsi.vidarr.api.SubmitWorkflowRequest;
@@ -367,6 +368,7 @@ public final class Main implements ServerConfig {
                             .get("/api/targets", monitor(server::fetchTargets))
                             .get("/api/url/{hash}", monitor(server::fetchUrl))
                             .get("/api/workflows", monitor(server::fetchWorkflows))
+                            .get("/api/max-in-flight", monitor(new BlockingHandler(server::fetchMaxInFlight)))
                             .get("/metrics", monitor(new BlockingHandler(Main::metrics)))
                             .post(
                                 "/api/provenance",
@@ -1131,6 +1133,31 @@ public final class Main implements ServerConfig {
 
   private void fetchFile(HttpServerExchange exchange) {
     fetchAnalysis(exchange, "file");
+  }
+
+  private void fetchMaxInFlight(HttpServerExchange exchange) {
+    exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
+    exchange.setStatusCode(StatusCodes.OK);
+    final var endTime = OffsetDateTime.now();
+    epochLock.readLock().lock();
+    try (final var output = MAPPER_FACTORY.createGenerator(exchange.getOutputStream())) {
+      InFlightCountsByWorkflow counts = maxInFlightPerWorkflow.getCountsByWorkflow();
+      output.writeStartObject();
+      output.writeNumberField("timestamp", endTime.toInstant().toEpochMilli());
+      output.writeObjectFieldStart("workflows");
+      for (String workflow: counts.getWorkflows()) {
+        output.writeObjectFieldStart(workflow);
+        output.writeNumberField("currentInFlight", counts.getCurrent(workflow));
+        output.writeNumberField("maxInFlight", counts.getMax(workflow));
+        output.writeEndObject();
+      }
+      output.writeEndObject();
+      output.writeEndObject();
+    } catch (Exception e) {
+      e.printStackTrace();
+      exchange.setStatusCode(StatusCodes.INTERNAL_SERVER_ERROR);
+      exchange.getResponseSender().send(e.getMessage());
+    }
   }
 
   private void fetchProvenance(HttpServerExchange exchange, AnalysisProvenanceRequest request) {

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
@@ -93,6 +93,25 @@ import org.postgresql.ds.PGSimpleDataSource;
 
 public final class Main implements ServerConfig {
 
+  private interface JsonPost<T> {
+    static <T> HttpHandler parse(Class<T> clazz, JsonPost<T> handler) {
+      return exchange ->
+          exchange
+              .getRequestReceiver()
+              .receiveFullBytes(
+                  (e, data) -> {
+                    try {
+                      handler.handleRequest(exchange, MAPPER.readValue(data, clazz));
+                    } catch (IOException exception) {
+                      exception.printStackTrace();
+                      e.setStatusCode(StatusCodes.BAD_REQUEST);
+                      e.getResponseSender().send(exception.getMessage());
+                    }
+                  });
+    }
+
+    void handleRequest(HttpServerExchange exchange, T body);
+  }
   static final HttpClient CLIENT =
       HttpClient.newBuilder()
           .version(HttpClient.Version.HTTP_1_1)
@@ -192,286 +211,6 @@ public final class Main implements ServerConfig {
                                 DSL.jsonEntry("type", ACTIVE_OPERATION.TYPE))))
                     .from(ACTIVE_OPERATION)
                     .where(ACTIVE_OPERATION.WORKFLOW_RUN_ID.eq(WORKFLOW_RUN.ID)))));
-  }
-
-  private final HikariDataSource dataSource;
-  private final ReentrantReadWriteLock epochLock = new ReentrantReadWriteLock();
-  private final ScheduledExecutorService executor =
-      Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
-  private final Map<String, InputProvisioner> inputProvisioners;
-  private final MaxInFlightByWorkflow maxInFlightPerWorkflow = new MaxInFlightByWorkflow();
-  private final Map<String, Optional<FileMetadata>> metadataCache = new ConcurrentHashMap<>();
-  private final Map<String, String> otherServers;
-  private final Map<String, OutputProvisioner> outputProvisioners;
-  private final int port;
-  private final DatabaseBackedProcessor processor;
-  private final Map<String, RuntimeProvisioner> runtimeProvisioners;
-  private final String selfName;
-  private final String selfUrl;
-  private final Map<String, Target> targets;
-  private final Map<String, WorkflowEngine> workflowEngines;
-  private final StatusPage status =
-      new StatusPage(this) {
-        @Override
-        protected void emitCore(SectionRenderer sectionRenderer) {
-          sectionRenderer.line("Self-URL", selfUrl);
-          for (final var target : targets.keySet()) {
-            sectionRenderer.line("Target", target);
-          }
-        }
-
-        @Override
-        public Stream<ConfigurationSection> sections() {
-          return Stream.of(
-                  workflowEngines.entrySet().stream()
-                      .map(
-                          e ->
-                              new ConfigurationSection("Workflow Engine: " + e.getKey()) {
-                                @Override
-                                public void emit(SectionRenderer sectionRenderer)
-                                    throws XMLStreamException {
-                                  e.getValue().configuration(sectionRenderer);
-                                }
-                              }),
-                  inputProvisioners.entrySet().stream()
-                      .map(
-                          e ->
-                              new ConfigurationSection("Input Provisioner: " + e.getKey()) {
-                                @Override
-                                public void emit(SectionRenderer sectionRenderer)
-                                    throws XMLStreamException {
-                                  e.getValue().configuration(sectionRenderer);
-                                }
-                              }),
-                  outputProvisioners.entrySet().stream()
-                      .map(
-                          e ->
-                              new ConfigurationSection("Output Provisioner: " + e.getKey()) {
-                                @Override
-                                public void emit(SectionRenderer sectionRenderer)
-                                    throws XMLStreamException {
-                                  e.getValue().configuration(sectionRenderer);
-                                }
-                              }),
-                  runtimeProvisioners.entrySet().stream()
-                      .map(
-                          e ->
-                              new ConfigurationSection("Runtime Provisioner: " + e.getKey()) {
-                                @Override
-                                public void emit(SectionRenderer sectionRenderer)
-                                    throws XMLStreamException {
-                                  e.getValue().configuration(sectionRenderer);
-                                }
-                              }))
-              .flatMap(Function.identity());
-        }
-      };
-  private long epoch = ManagementFactory.getRuntimeMXBean().getStartTime();
-  private Main(ServerConfiguration configuration) throws SQLException {
-    selfUrl = configuration.getUrl();
-    selfName = configuration.getName();
-    port = configuration.getPort();
-    otherServers = configuration.getOtherServers();
-    workflowEngines =
-        load(
-            "Workflow engine",
-            WorkflowEngineProvider.class,
-            WorkflowEngineProvider::type,
-            WorkflowEngineProvider::readConfiguration,
-            configuration.getWorkflowEngines(),
-            new RemoteWorkflowEngineProvider());
-    inputProvisioners =
-        load(
-            "Input Provisioner",
-            InputProvisionerProvider.class,
-            InputProvisionerProvider::type,
-            InputProvisionerProvider::readConfiguration,
-            configuration.getInputProvisioners(),
-            new RemoteInputProvisionerProvider());
-    outputProvisioners =
-        load(
-            "Output Provisioner",
-            OutputProvisionerProvider.class,
-            OutputProvisionerProvider::type,
-            OutputProvisionerProvider::readConfiguration,
-            configuration.getOutputProvisioners(),
-            new RemoteOutputProvisionerProvider());
-    runtimeProvisioners =
-        load(
-            "Runtime Provisioner",
-            RuntimeProvisionerProvider.class,
-            RuntimeProvisionerProvider::name,
-            RuntimeProvisionerProvider::readConfiguration,
-            configuration.getRuntimeProvisioners(),
-            new RemoteRuntimeProvisionerProvider());
-    final var consumableResources = loadConsumableResources(configuration.getConsumableResources());
-    targets =
-        configuration.getTargets().entrySet().stream()
-            .collect(
-                Collectors.toMap(
-                    Map.Entry::getKey,
-                    e ->
-                        new Target() {
-                          private final WorkflowEngine engine =
-                              workflowEngines.get(e.getValue().getWorkflowEngine());
-                          private final Map<InputProvisionFormat, InputProvisioner>
-                              inputProvisioners =
-                                  e.getValue().getInputProvisioners().stream()
-                                      .map(Main.this.inputProvisioners::get)
-                                      .flatMap(
-                                          p ->
-                                              Stream.of(InputProvisionFormat.values())
-                                                  .filter(p::canProvision)
-                                                  .map(f -> new Pair<>(f, p)))
-                                      .collect(
-                                          Collectors
-                                              .<Pair<InputProvisionFormat, InputProvisioner>,
-                                                  InputProvisionFormat, InputProvisioner>
-                                                  toMap(Pair::first, Pair::second));
-                          private final Map<OutputProvisionFormat, OutputProvisioner>
-                              outputProvisioners =
-                                  e.getValue().getOutputProvisioners().stream()
-                                      .map(Main.this.outputProvisioners::get)
-                                      .flatMap(
-                                          p ->
-                                              Stream.of(OutputProvisionFormat.values())
-                                                  .filter(p::canProvision)
-                                                  .map(f -> new Pair<>(f, p)))
-                                      .collect(
-                                          Collectors
-                                              .<Pair<OutputProvisionFormat, OutputProvisioner>,
-                                                  OutputProvisionFormat, OutputProvisioner>
-                                                  toMap(Pair::first, Pair::second));
-                          private final List<RuntimeProvisioner> runtimeProvisioners =
-                              e.getValue().getRuntimeProvisioners().stream()
-                                  .map(Main.this.runtimeProvisioners::get)
-                                  .collect(Collectors.toList());
-                          private final List<ConsumableResource> consumables =
-                              Stream.concat(
-                                      e.getValue().getConsumableResources().stream()
-                                          .map(consumableResources::get),
-                                      Stream.of(maxInFlightPerWorkflow))
-                                  .collect(Collectors.toList());
-
-                          @Override
-                          public Stream<ConsumableResource> consumableResources() {
-                            return consumables.stream();
-                          }
-
-                          @Override
-                          public WorkflowEngine engine() {
-                            return engine;
-                          }
-
-                          @Override
-                          public InputProvisioner provisionerFor(InputProvisionFormat type) {
-                            return inputProvisioners.get(type);
-                          }
-
-                          @Override
-                          public OutputProvisioner provisionerFor(OutputProvisionFormat type) {
-                            return outputProvisioners.get(type);
-                          }
-
-                          @Override
-                          public Stream<RuntimeProvisioner> runtimeProvisioners() {
-                            return runtimeProvisioners.stream();
-                          }
-                        }));
-
-    final var simpleConnection = new PGSimpleDataSource();
-    simpleConnection.setServerNames(new String[] {configuration.getDbHost()});
-    simpleConnection.setPortNumbers(new int[] {configuration.getDbPort()});
-    simpleConnection.setDatabaseName(configuration.getDbName());
-    simpleConnection.setUser(configuration.getDbUser());
-    simpleConnection.setPassword(configuration.getDbPass());
-    Flyway.configure().dataSource(simpleConnection).load().migrate();
-
-    final var config = new HikariConfig();
-    config.setJdbcUrl(
-        String.format(
-            "jdbc:postgresql://%s:%d/%s",
-            configuration.getDbHost(), configuration.getDbPort(), configuration.getDbName()));
-    config.setUsername(configuration.getDbUser());
-    config.setPassword(configuration.getDbPass());
-    config.setAutoCommit(false);
-    config.setTransactionIsolation("TRANSACTION_REPEATABLE_READ");
-    dataSource = new HikariDataSource(config);
-    // This limit is selected because of the default maximum number of connections supported by
-    // Postgres
-    dataSource.setMaximumPoolSize(Math.min(10 * Runtime.getRuntime().availableProcessors(), 95));
-    processor =
-        new DatabaseBackedProcessor(executor, dataSource) {
-          private Optional<FileMetadata> fetchPathForId(String id) {
-            final var match = BaseProcessor.ANALYSIS_RECORD_ID.matcher(id);
-            if (!match.matches() || !match.group("type").equals("file")) {
-              return Optional.empty();
-            }
-            final var instance = match.group("instance");
-            final var hash = match.group("hash");
-            if (instance.equals("_") || instance.equals(selfName)) {
-              return resolveInDatabase(hash);
-            }
-            final var remote = otherServers.get(instance);
-            if (remote == null) {
-              return Optional.empty();
-            }
-
-            try (final var ignored = REMOTE_RESPONSE_TIME.start(remote)) {
-              final var response =
-                  CLIENT.send(
-                      HttpRequest.newBuilder()
-                          .uri(URI.create(String.format("%s/api/file/%s", remote, hash)))
-                          .timeout(Duration.ofMinutes(1))
-                          .GET()
-                          .build(),
-                      new JsonBodyHandler<>(
-                          MAPPER, new TypeReference<ProvenanceAnalysisRecord<ExternalKey>>() {}));
-              if (response.statusCode() == HttpURLConnection.HTTP_OK) {
-                final var result = response.body().get();
-                return Optional.of(
-                    new FileMetadata() {
-                      private final List<ExternalKey> keys = result.getExternalKeys();
-                      private final String path = result.getFilePath();
-
-                      @Override
-                      public Stream<ExternalKey> externalKeys() {
-                        return keys.stream();
-                      }
-
-                      @Override
-                      public String path() {
-                        return path;
-                      }
-                    });
-              } else {
-                return Optional.empty();
-              }
-
-            } catch (Exception e) {
-              e.printStackTrace();
-              REMOTE_ERROR_COUNT.labels(remote).inc();
-              return Optional.empty();
-            }
-          }
-
-          @Override
-          public Optional<FileMetadata> pathForId(String id) {
-            return metadataCache.computeIfAbsent(id, this::fetchPathForId);
-          }
-
-          @Override
-          protected Optional<Target> targetByName(String name) {
-            return Optional.ofNullable(targets.get(name));
-          }
-        };
-
-    try (final var connection = dataSource.getConnection()) {
-      DSL.using(connection, SQLDialect.POSTGRES)
-          .select(WORKFLOW.NAME, WORKFLOW.MAX_IN_FLIGHT)
-          .from(WORKFLOW)
-          .forEach(record -> maxInFlightPerWorkflow.set(record.value1(), record.value2()));
-    }
   }
 
   private static Field<?> createQuery(VersionPolicy policy, Set<String> allowedTypes) {
@@ -696,6 +435,286 @@ public final class Main implements ServerConfig {
         handler.handleRequest(exchange);
       }
     };
+  }
+  private final HikariDataSource dataSource;
+  private long epoch = ManagementFactory.getRuntimeMXBean().getStartTime();
+  private final ReentrantReadWriteLock epochLock = new ReentrantReadWriteLock();
+  private final ScheduledExecutorService executor =
+      Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
+  private final Map<String, InputProvisioner> inputProvisioners;
+  private final MaxInFlightByWorkflow maxInFlightPerWorkflow = new MaxInFlightByWorkflow();
+  private final Map<String, Optional<FileMetadata>> metadataCache = new ConcurrentHashMap<>();
+  private final Map<String, String> otherServers;
+  private final Map<String, OutputProvisioner> outputProvisioners;
+  private final int port;
+  private final DatabaseBackedProcessor processor;
+  private final Map<String, RuntimeProvisioner> runtimeProvisioners;
+  private final String selfName;
+  private final String selfUrl;
+  private final Map<String, Target> targets;
+  private final Map<String, WorkflowEngine> workflowEngines;
+  private final StatusPage status =
+      new StatusPage(this) {
+        @Override
+        protected void emitCore(SectionRenderer sectionRenderer) {
+          sectionRenderer.line("Self-URL", selfUrl);
+          for (final var target : targets.keySet()) {
+            sectionRenderer.line("Target", target);
+          }
+        }
+
+        @Override
+        public Stream<ConfigurationSection> sections() {
+          return Stream.of(
+                  workflowEngines.entrySet().stream()
+                      .map(
+                          e ->
+                              new ConfigurationSection("Workflow Engine: " + e.getKey()) {
+                                @Override
+                                public void emit(SectionRenderer sectionRenderer)
+                                    throws XMLStreamException {
+                                  e.getValue().configuration(sectionRenderer);
+                                }
+                              }),
+                  inputProvisioners.entrySet().stream()
+                      .map(
+                          e ->
+                              new ConfigurationSection("Input Provisioner: " + e.getKey()) {
+                                @Override
+                                public void emit(SectionRenderer sectionRenderer)
+                                    throws XMLStreamException {
+                                  e.getValue().configuration(sectionRenderer);
+                                }
+                              }),
+                  outputProvisioners.entrySet().stream()
+                      .map(
+                          e ->
+                              new ConfigurationSection("Output Provisioner: " + e.getKey()) {
+                                @Override
+                                public void emit(SectionRenderer sectionRenderer)
+                                    throws XMLStreamException {
+                                  e.getValue().configuration(sectionRenderer);
+                                }
+                              }),
+                  runtimeProvisioners.entrySet().stream()
+                      .map(
+                          e ->
+                              new ConfigurationSection("Runtime Provisioner: " + e.getKey()) {
+                                @Override
+                                public void emit(SectionRenderer sectionRenderer)
+                                    throws XMLStreamException {
+                                  e.getValue().configuration(sectionRenderer);
+                                }
+                              }))
+              .flatMap(Function.identity());
+        }
+      };
+
+  private Main(ServerConfiguration configuration) throws SQLException {
+    selfUrl = configuration.getUrl();
+    selfName = configuration.getName();
+    port = configuration.getPort();
+    otherServers = configuration.getOtherServers();
+    workflowEngines =
+        load(
+            "Workflow engine",
+            WorkflowEngineProvider.class,
+            WorkflowEngineProvider::type,
+            WorkflowEngineProvider::readConfiguration,
+            configuration.getWorkflowEngines(),
+            new RemoteWorkflowEngineProvider());
+    inputProvisioners =
+        load(
+            "Input Provisioner",
+            InputProvisionerProvider.class,
+            InputProvisionerProvider::type,
+            InputProvisionerProvider::readConfiguration,
+            configuration.getInputProvisioners(),
+            new RemoteInputProvisionerProvider());
+    outputProvisioners =
+        load(
+            "Output Provisioner",
+            OutputProvisionerProvider.class,
+            OutputProvisionerProvider::type,
+            OutputProvisionerProvider::readConfiguration,
+            configuration.getOutputProvisioners(),
+            new RemoteOutputProvisionerProvider());
+    runtimeProvisioners =
+        load(
+            "Runtime Provisioner",
+            RuntimeProvisionerProvider.class,
+            RuntimeProvisionerProvider::name,
+            RuntimeProvisionerProvider::readConfiguration,
+            configuration.getRuntimeProvisioners(),
+            new RemoteRuntimeProvisionerProvider());
+    final var consumableResources = loadConsumableResources(configuration.getConsumableResources());
+    targets =
+        configuration.getTargets().entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    Map.Entry::getKey,
+                    e ->
+                        new Target() {
+                          private final List<ConsumableResource> consumables =
+                              Stream.concat(
+                                      e.getValue().getConsumableResources().stream()
+                                          .map(consumableResources::get),
+                                      Stream.of(maxInFlightPerWorkflow))
+                                  .collect(Collectors.toList());
+                          private final WorkflowEngine engine =
+                              workflowEngines.get(e.getValue().getWorkflowEngine());
+                          private final Map<InputProvisionFormat, InputProvisioner>
+                              inputProvisioners =
+                                  e.getValue().getInputProvisioners().stream()
+                                      .map(Main.this.inputProvisioners::get)
+                                      .flatMap(
+                                          p ->
+                                              Stream.of(InputProvisionFormat.values())
+                                                  .filter(p::canProvision)
+                                                  .map(f -> new Pair<>(f, p)))
+                                      .collect(
+                                          Collectors
+                                              .<Pair<InputProvisionFormat, InputProvisioner>,
+                                                  InputProvisionFormat, InputProvisioner>
+                                                  toMap(Pair::first, Pair::second));
+                          private final Map<OutputProvisionFormat, OutputProvisioner>
+                              outputProvisioners =
+                                  e.getValue().getOutputProvisioners().stream()
+                                      .map(Main.this.outputProvisioners::get)
+                                      .flatMap(
+                                          p ->
+                                              Stream.of(OutputProvisionFormat.values())
+                                                  .filter(p::canProvision)
+                                                  .map(f -> new Pair<>(f, p)))
+                                      .collect(
+                                          Collectors
+                                              .<Pair<OutputProvisionFormat, OutputProvisioner>,
+                                                  OutputProvisionFormat, OutputProvisioner>
+                                                  toMap(Pair::first, Pair::second));
+                          private final List<RuntimeProvisioner> runtimeProvisioners =
+                              e.getValue().getRuntimeProvisioners().stream()
+                                  .map(Main.this.runtimeProvisioners::get)
+                                  .collect(Collectors.toList());
+
+                          @Override
+                          public Stream<ConsumableResource> consumableResources() {
+                            return consumables.stream();
+                          }
+
+                          @Override
+                          public WorkflowEngine engine() {
+                            return engine;
+                          }
+
+                          @Override
+                          public InputProvisioner provisionerFor(InputProvisionFormat type) {
+                            return inputProvisioners.get(type);
+                          }
+
+                          @Override
+                          public OutputProvisioner provisionerFor(OutputProvisionFormat type) {
+                            return outputProvisioners.get(type);
+                          }
+
+                          @Override
+                          public Stream<RuntimeProvisioner> runtimeProvisioners() {
+                            return runtimeProvisioners.stream();
+                          }
+                        }));
+
+    final var simpleConnection = new PGSimpleDataSource();
+    simpleConnection.setServerNames(new String[] {configuration.getDbHost()});
+    simpleConnection.setPortNumbers(new int[] {configuration.getDbPort()});
+    simpleConnection.setDatabaseName(configuration.getDbName());
+    simpleConnection.setUser(configuration.getDbUser());
+    simpleConnection.setPassword(configuration.getDbPass());
+    Flyway.configure().dataSource(simpleConnection).load().migrate();
+
+    final var config = new HikariConfig();
+    config.setJdbcUrl(
+        String.format(
+            "jdbc:postgresql://%s:%d/%s",
+            configuration.getDbHost(), configuration.getDbPort(), configuration.getDbName()));
+    config.setUsername(configuration.getDbUser());
+    config.setPassword(configuration.getDbPass());
+    config.setAutoCommit(false);
+    config.setTransactionIsolation("TRANSACTION_REPEATABLE_READ");
+    dataSource = new HikariDataSource(config);
+    // This limit is selected because of the default maximum number of connections supported by
+    // Postgres
+    dataSource.setMaximumPoolSize(Math.min(10 * Runtime.getRuntime().availableProcessors(), 95));
+    processor =
+        new DatabaseBackedProcessor(executor, dataSource) {
+          private Optional<FileMetadata> fetchPathForId(String id) {
+            final var match = BaseProcessor.ANALYSIS_RECORD_ID.matcher(id);
+            if (!match.matches() || !match.group("type").equals("file")) {
+              return Optional.empty();
+            }
+            final var instance = match.group("instance");
+            final var hash = match.group("hash");
+            if (instance.equals("_") || instance.equals(selfName)) {
+              return resolveInDatabase(hash);
+            }
+            final var remote = otherServers.get(instance);
+            if (remote == null) {
+              return Optional.empty();
+            }
+
+            try (final var ignored = REMOTE_RESPONSE_TIME.start(remote)) {
+              final var response =
+                  CLIENT.send(
+                      HttpRequest.newBuilder()
+                          .uri(URI.create(String.format("%s/api/file/%s", remote, hash)))
+                          .timeout(Duration.ofMinutes(1))
+                          .GET()
+                          .build(),
+                      new JsonBodyHandler<>(
+                          MAPPER, new TypeReference<ProvenanceAnalysisRecord<ExternalKey>>() {}));
+              if (response.statusCode() == HttpURLConnection.HTTP_OK) {
+                final var result = response.body().get();
+                return Optional.of(
+                    new FileMetadata() {
+                      private final List<ExternalKey> keys = result.getExternalKeys();
+                      private final String path = result.getFilePath();
+
+                      @Override
+                      public Stream<ExternalKey> externalKeys() {
+                        return keys.stream();
+                      }
+
+                      @Override
+                      public String path() {
+                        return path;
+                      }
+                    });
+              } else {
+                return Optional.empty();
+              }
+
+            } catch (Exception e) {
+              e.printStackTrace();
+              REMOTE_ERROR_COUNT.labels(remote).inc();
+              return Optional.empty();
+            }
+          }
+
+          @Override
+          public Optional<FileMetadata> pathForId(String id) {
+            return metadataCache.computeIfAbsent(id, this::fetchPathForId);
+          }
+
+          @Override
+          protected Optional<Target> targetByName(String name) {
+            return Optional.ofNullable(targets.get(name));
+          }
+        };
+
+    try (final var connection = dataSource.getConnection()) {
+      DSL.using(connection, SQLDialect.POSTGRES)
+          .select(WORKFLOW.NAME, WORKFLOW.MAX_IN_FLIGHT)
+          .from(WORKFLOW)
+          .forEach(record -> maxInFlightPerWorkflow.set(record.value1(), record.value2()));
+    }
   }
 
   private void addWorkflow(HttpServerExchange exchange, AddWorkflowRequest request) {
@@ -1508,25 +1527,5 @@ public final class Main implements ServerConfig {
     } catch (Exception e) {
       e.printStackTrace();
     }
-  }
-
-  private interface JsonPost<T> {
-    static <T> HttpHandler parse(Class<T> clazz, JsonPost<T> handler) {
-      return exchange ->
-          exchange
-              .getRequestReceiver()
-              .receiveFullBytes(
-                  (e, data) -> {
-                    try {
-                      handler.handleRequest(exchange, MAPPER.readValue(data, clazz));
-                    } catch (IOException exception) {
-                      exception.printStackTrace();
-                      e.setStatusCode(StatusCodes.BAD_REQUEST);
-                      e.getResponseSender().send(exception.getMessage());
-                    }
-                  });
-    }
-
-    void handleRequest(HttpServerExchange exchange, T body);
   }
 }

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/MaxInFlightByWorkflow.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/MaxInFlightByWorkflow.java
@@ -1,5 +1,6 @@
 package ca.on.oicr.gsi.vidarr.server;
 
+import ca.on.oicr.gsi.vidarr.api.InFlightCountsByWorkflow;
 import ca.on.oicr.gsi.Pair;
 import ca.on.oicr.gsi.vidarr.BasicType;
 import ca.on.oicr.gsi.vidarr.ConsumableResource;
@@ -73,6 +74,22 @@ final class MaxInFlightByWorkflow implements ConsumableResource {
             String.format("The maximum number of %s workflows has been reached.", workflowName));
       }
     }
+  }
+
+  /**
+   * Get summary information for each workflow: workflowName -> (currentInFlight, maxInFlight)
+   */
+  public InFlightCountsByWorkflow getCountsByWorkflow() {
+
+    InFlightCountsByWorkflow counts = new InFlightCountsByWorkflow();
+    for (String name : workflows.keySet()) {
+      counts.add(
+		 name,
+		 workflows.get(name).running.size(),
+		 workflows.get(name).maximum
+		 );
+    }
+    return counts;
   }
 
   public void set(String workflowName, int maxInFlight) {

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/MaxInFlightByWorkflow.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/MaxInFlightByWorkflow.java
@@ -13,11 +13,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 final class MaxInFlightByWorkflow implements ConsumableResource {
-  private static final class MaxState {
-    private int maximum;
-    private final Set<String> running = ConcurrentHashMap.newKeySet();
-  }
-
   private static final Gauge currentInFlightCount =
       Gauge.build(
               "vidarr_in_flight_per_workflow_current",
@@ -95,5 +90,10 @@ final class MaxInFlightByWorkflow implements ConsumableResource {
   public void set(String workflowName, int maxInFlight) {
     maxInFlightCount.labels(workflowName).set(maxInFlight);
     workflows.computeIfAbsent(workflowName, k -> new MaxState()).maximum = maxInFlight;
+  }
+
+  private static final class MaxState {
+    private final Set<String> running = ConcurrentHashMap.newKeySet();
+    private int maximum;
   }
 }


### PR DESCRIPTION
- Successful test on a local Vidarr server:
`ibancarz@ld5312-ibanca:~/git/vidarr$ curl http://localhost:8088/api/max-in-flight && echo ""
{"timestamp":1614879464581,"workflows":{"bcl2barcode":{"currentInFlight":0,"maxInFlight":20}}}
`

- This is parts 1&2 of the ticket, modifications to Shesmu are next.
- Timestamp is not essential, but might be useful if we want to know when the current-in-flight value is from.
- Modification to `.gitignore` is to ignore emacs temporary files.