### PR TITLE
Fix contract bug in Cromwell output provisioner and workflow engine

### DIFF
--- a/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/CromwellWorkflowEngine.java
+++ b/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/CromwellWorkflowEngine.java
@@ -227,7 +227,7 @@ public final class CromwellWorkflowEngine
   @Override
   protected void recover(EngineState state, WorkMonitor<Result<String>, EngineState> monitor) {
     if (state.getCromwellId() == null) {
-      startTask(state, monitor);
+      monitor.scheduleTask(() -> startTask(state, monitor));
     } else {
       check(state, monitor);
     }

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/InputProvisioner.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/InputProvisioner.java
@@ -24,6 +24,10 @@ public interface InputProvisioner {
   /**
    * Begin provisioning out a new input that was registered in Vidarr
    *
+   * <p>This method should not do any externally-visible work. Anything it needs should be done in a
+   * {@link WorkMonitor#scheduleTask(Runnable)} callback so that Vidarr can execute it once the
+   * database is in a healthy state.
+   *
    * @param language the workflow language the output will be consumed by
    * @param id the Vidarr ID for the file
    * @param path the output path registered in Vidarr for the file
@@ -36,6 +40,10 @@ public interface InputProvisioner {
   /**
    * Begin provisioning out a new input that was not registered in Vidarr
    *
+   * <p>This method should not do any externally-visible work. Anything it needs should be done in a
+   * {@link WorkMonitor#scheduleTask(Runnable)} callback so that Vidarr can execute it once the
+   * database is in a healthy state.
+   *
    * @param language the workflow language the output will be consumed by
    * @param metadata the information coming from the submitter to direct provisioning
    * @param monitor the monitor structure for writing the output of the provisioning process
@@ -46,6 +54,10 @@ public interface InputProvisioner {
 
   /**
    * Restart a provisioning process from state saved in the database
+   *
+   * <p>This method should not do any externally-visible work. Anything it needs should be done in a
+   * {@link WorkMonitor#scheduleTask(Runnable)} callback so that Vidarr can execute it once the
+   * database is in a healthy state.
    *
    * @param state the frozen database state
    * @param monitor the monitor structure for writing the output of the provisioning process

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/OutputProvisioner.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/OutputProvisioner.java
@@ -103,6 +103,10 @@ public interface OutputProvisioner {
   /**
    * Begin provisioning out a new output
    *
+   * <p>This method should not do any externally-visible work. Anything it needs should be done in a
+   * {@link WorkMonitor#scheduleTask(Runnable)} callback so that Vidarr can execute it once the
+   * database is in a healthy state.
+   *
    * @param workflowRunId the workflow run ID assigned by Vidarr
    * @param data the output coming from the workflow
    * @param metadata the information coming from the submitter to direct provisioning
@@ -114,6 +118,10 @@ public interface OutputProvisioner {
 
   /**
    * Restart a provisioning process from state saved in the database
+   *
+   * <p>This method should not do any externally-visible work. Anything it needs should be done in a
+   * {@link WorkMonitor#scheduleTask(Runnable)} callback so that Vidarr can execute it once the
+   * database is in a healthy state.
    *
    * @param state the frozen database state
    * @param monitor the monitor structure for writing the output of the provisioning process

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/WorkflowEngine.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/WorkflowEngine.java
@@ -54,6 +54,10 @@ public interface WorkflowEngine {
    * Clean up the output of a workflow (i.e., delete its on-disk output) after provisioning has been
    * completed.
    *
+   * <p>This method should not do any externally-visible work. Anything it needs should be done in a
+   * {@link WorkMonitor#scheduleTask(Runnable)} callback so that Vidarr can execute it once the
+   * database is in a healthy state.
+   *
    * @param cleanupState the clean up state provided with the workflow's output
    * @param monitor the monitor structure for clean up process; since no output is required, supply
    *     null as the output value
@@ -74,6 +78,10 @@ public interface WorkflowEngine {
   /**
    * Restart a running process from state saved in the database
    *
+   * <p>This method should not do any externally-visible work. Anything it needs should be done in a
+   * {@link WorkMonitor#scheduleTask(Runnable)} callback so that Vidarr can execute it once the
+   * database is in a healthy state.
+   *
    * @param state the frozen database state
    * @param monitor the monitor structure for writing the output of the workflow process
    */
@@ -82,6 +90,10 @@ public interface WorkflowEngine {
   /**
    * Restart a running clean up process from state saved in the database
    *
+   * <p>This method should not do any externally-visible work. Anything it needs should be done in a
+   * {@link WorkMonitor#scheduleTask(Runnable)} callback so that Vidarr can execute it once the
+   * database is in a healthy state.
+   *
    * @param state the frozen database state
    * @param monitor the monitor structure for writing the output of the cleanup process
    */
@@ -89,6 +101,10 @@ public interface WorkflowEngine {
 
   /**
    * Start a new workflow
+   *
+   * <p>This method should not do any externally-visible work. Anything it needs should be done in a
+   * {@link WorkMonitor#scheduleTask(Runnable)} callback so that Vidarr can execute it once the
+   * database is in a healthy state.
    *
    * @param workflowLanguage the language the workflow was written in
    * @param workflow the contents of the workflow


### PR DESCRIPTION
The Vidarr interface requires that no real work be done in the `provision`,
`run`, or `recover` methods. The Cromwell output provisioner's `provision` and
`recover` started a job immediately and the Cromwell workflow engine's
`recover` might start a job immediately. This uses the scheduler to do these
operations only after the calling method is done.