### PR TITLE
Add Jackson `java.time` support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,11 @@
         <version>[2.11.0, )</version>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jsr310</artifactId>
+        <version>[2.11.0, )</version>
+      </dependency>
+      <dependency>
         <groupId>io.undertow</groupId>
         <artifactId>undertow-core</artifactId>
         <version>2.2.2.Final</version>

--- a/vidarr-server/pom.xml
+++ b/vidarr-server/pom.xml
@@ -19,6 +19,10 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.undertow</groupId>
       <artifactId>undertow-core</artifactId>
     </dependency>

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
@@ -38,7 +38,9 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import io.prometheus.client.CollectorRegistry;
@@ -138,6 +140,8 @@ public final class Main implements ServerConfig {
   private static final List<JSONEntry<?>> STATUS_FIELDS = new ArrayList<>();
 
   static {
+    MAPPER.registerModule(new JavaTimeModule());
+    MAPPER.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
     STATUS_FIELDS.add(DSL.jsonEntry("completed", WORKFLOW_RUN.COMPLETED));
     STATUS_FIELDS.add(
         DSL.jsonEntry(

--- a/vidarr-server/src/main/java/module-info.java
+++ b/vidarr-server/src/main/java/module-info.java
@@ -11,6 +11,7 @@ module ca.on.oicr.gsi.vidarr.server {
   requires ca.on.oicr.gsi.vidarr.pluginapi;
   requires com.fasterxml.jackson.core;
   requires com.fasterxml.jackson.databind;
+  requires com.fasterxml.jackson.datatype.jsr310;
   requires HikariCP;
   requires java.management;
   requires java.naming;


### PR DESCRIPTION
The JSR310 plugin is required to make use of the `java.time` classes found in
some DTOs.