### PR TITLE
Add load/unload functionality

### DIFF
--- a/plugin-guide.md
+++ b/plugin-guide.md
@@ -96,9 +96,27 @@ The class `BaseJsonWorkflowEngine` is a partial implementation that can store
 crash recovery information in a JSON object of the implementor's choosing,
 making recovery easier.
 
-# Unloaders
-Unloader implement `ca.on.oicr.gsi.vidarr.UnloaderProvider`
-and `ca.on.oicr.gsi.vidarr.Unloader`. This feature is not complete, so these
-interfaces are not ready for use.
+# Unload Filters
+Unload filters implement `ca.on.oicr.gsi.vidarr.UnloadFilterProvider` and
+`ca.on.oicr.gsi.vidarr.UnloadFilter`. These plugins allow customisable
+selection of workflows for unloading. For an understanding of unloading
+filters, see [Loading and Unloading](load-unload.md).
 
-TODO
+The user will specify a filter as a JSON object with a `"type"` property. The
+classes implementing `UnloadFilter` will be deserialized by Jackson. The
+`UnloadFilterProvider` associates the strings used in `"type"` to the objects.
+One provider can provide multiple filter types. The types used should be
+_plugin_`-`_filter_; names without dashes and names starting with `vidarr-` are
+reserved by Vidarr. The _filter_ can have dashes in it if desired. If two
+plugins provide duplicate type names, Vidarr will fail to load.
+
+Once a filter is deserialised, it needs to convert the request into a query
+Vidarr can apply to its database. That is, it needs to be converted to a query
+made of only workflow, workflow run, and external key matches. The server will
+call `convert` with an `UnloadFilter.Visitor` so that the filter can determine
+whatever information it needs and generate an output query.
+
+For example, if external keys are connected to Pinery, then a filter might want
+to filter on runs. A filter could query Pinery and get all the external
+identifiers associated with that run and then construct a query based on those
+to match workflow runs that use any of those identifiers.

--- a/vidarr-core/src/main/java/module-info.java
+++ b/vidarr-core/src/main/java/module-info.java
@@ -1,6 +1,7 @@
 import ca.on.oicr.gsi.vidarr.ConsumableResourceProvider;
 import ca.on.oicr.gsi.vidarr.InputProvisionerProvider;
 import ca.on.oicr.gsi.vidarr.OutputProvisionerProvider;
+import ca.on.oicr.gsi.vidarr.UnloadFilterProvider;
 import ca.on.oicr.gsi.vidarr.WorkflowEngineProvider;
 import ca.on.oicr.gsi.vidarr.core.MaxInFlightConsumableResource;
 import ca.on.oicr.gsi.vidarr.core.OneOfInputProvisioner;
@@ -22,6 +23,7 @@ module ca.on.oicr.gsi.vidarr.core {
 
   uses InputProvisionerProvider;
   uses OutputProvisionerProvider;
+  uses UnloadFilterProvider;
   uses WorkflowEngineProvider;
 
   provides ConsumableResourceProvider with

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/UnloadFilter.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/UnloadFilter.java
@@ -1,0 +1,215 @@
+package ca.on.oicr.gsi.vidarr;
+
+import ca.on.oicr.gsi.Pair;
+import ca.on.oicr.gsi.vidarr.api.UnloadFilterAnalysisId;
+import ca.on.oicr.gsi.vidarr.api.UnloadFilterAnd;
+import ca.on.oicr.gsi.vidarr.api.UnloadFilterCompletedAfter;
+import ca.on.oicr.gsi.vidarr.api.UnloadFilterExternalId;
+import ca.on.oicr.gsi.vidarr.api.UnloadFilterExternalProvider;
+import ca.on.oicr.gsi.vidarr.api.UnloadFilterLastSubmittedAfter;
+import ca.on.oicr.gsi.vidarr.api.UnloadFilterNot;
+import ca.on.oicr.gsi.vidarr.api.UnloadFilterOr;
+import ca.on.oicr.gsi.vidarr.api.UnloadFilterWorkflowId;
+import ca.on.oicr.gsi.vidarr.api.UnloadFilterWorkflowName;
+import ca.on.oicr.gsi.vidarr.api.UnloadFilterWorkflowRunId;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.databind.DatabindContext;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.SerializationConfig;
+import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
+import com.fasterxml.jackson.databind.jsontype.NamedType;
+import com.fasterxml.jackson.databind.jsontype.TypeDeserializer;
+import com.fasterxml.jackson.databind.jsontype.TypeSerializer;
+import com.fasterxml.jackson.databind.jsontype.impl.StdTypeResolverBuilder;
+import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.ServiceLoader;
+import java.util.ServiceLoader.Provider;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Defines a JSON object for unloading records
+ *
+ * <p>Since Vidarr knows about external systems, it is desirable for those external systems to be
+ * used as a way to select the records that should be included.
+ */
+@JsonTypeIdResolver(UnloadFilter.UnloadFilterIdResolver.class)
+@JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, include = As.PROPERTY, property = "type")
+public interface UnloadFilter {
+  /**
+   * A mechanism to build the filter from primitive.
+   *
+   * @param <T> the type of the filter being constructed
+   */
+  interface Visitor<T> {
+
+    /**
+     * Create a match for workflow runs that produced certain files or URLS, by their Vidarr IDs.
+     *
+     * @param ids the analysis identifiers to match
+     */
+    T analysisId(Stream<String> ids);
+
+    /**
+     * Require a match of all the clauses provided.
+     *
+     * @param clauses the filters to include
+     */
+    T and(Stream<T> clauses);
+
+    /**
+     * Requires that the completion time of the workflow as submitted is after the specified
+     * timestamp
+     *
+     * @param time the timestamp to check
+     */
+    T completedAfter(Instant time);
+
+    /**
+     * Create a match for workflow runs that include an external key with any of the providers
+     * listed.
+     *
+     * @param providers the providers to match
+     */
+    T externalKey(Stream<String> providers);
+
+    /**
+     * Create a match for workflow runs that include an external key with the provider listed and
+     * any of the identifiers provided.
+     *
+     * @param provider the external provider to match
+     * @param ids the external identifiers to match
+     */
+    T externalKey(String provider, Stream<String> ids);
+
+    /**
+     * Requires that the last time the workflow as submitted is after the specified timestamp
+     *
+     * @param time the timestamp to check
+     */
+    T lastSubmittedAfter(Instant time);
+
+    /**
+     * Invert the result of a filter.
+     *
+     * @param clause the filter to invert
+     */
+    T not(T clause);
+
+    /**
+     * A filter which is constantly one value
+     *
+     * @param value the value the filter should return
+     */
+    T of(boolean value);
+
+    /**
+     * Require a match of any the clauses provided.
+     *
+     * @param clauses the filters to include
+     */
+    T or(Stream<T> clauses);
+
+    /**
+     * Match any of the workflow Vidarr identifiers (versions) provided.
+     *
+     * @param ids the workflow identifiers to match
+     */
+    T workflowId(Stream<String> ids);
+
+    /**
+     * Match any of the workflow names provided.
+     *
+     * @param names the human-readable workflow names to match
+     */
+    T workflowName(Stream<String> names);
+
+    /**
+     * Match any of the workflow run Vidarr identifiers provided.
+     *
+     * @param ids the workflow identifiers to match
+     */
+    T workflowRunId(Stream<String> ids);
+  }
+
+  final class UnloadFilterIdResolver extends TypeIdResolverBase {
+    private final Map<String, Class<? extends UnloadFilter>> knownIds =
+        Stream.concat(
+                Stream.of(
+                    new Pair<>("and", UnloadFilterAnd.class),
+                    new Pair<>("not", UnloadFilterNot.class),
+                    new Pair<>("or", UnloadFilterOr.class),
+                    new Pair<>("vidarr-analysis-id", UnloadFilterAnalysisId.class),
+                    new Pair<>("vidarr-completed-after", UnloadFilterCompletedAfter.class),
+                    new Pair<>("vidarr-external-id", UnloadFilterExternalId.class),
+                    new Pair<>("vidarr-external-provider", UnloadFilterExternalProvider.class),
+                    new Pair<>("vidarr-last-submitted-after", UnloadFilterLastSubmittedAfter.class),
+                    new Pair<>("vidarr-workflow-id", UnloadFilterWorkflowId.class),
+                    new Pair<>("vidarr-workflow-name", UnloadFilterWorkflowName.class),
+                    new Pair<>("vidarr-workflow-run-id", UnloadFilterWorkflowRunId.class)),
+                ServiceLoader.load(UnloadFilterProvider.class).stream()
+                    .map(Provider::get)
+                    .flatMap(UnloadFilterProvider::types))
+            .collect(Collectors.toMap(Pair::first, Pair::second));
+
+    @Override
+    public Id getMechanism() {
+      return Id.CUSTOM;
+    }
+
+    @Override
+    public String idFromValue(Object o) {
+      return knownIds.entrySet().stream()
+          .filter(known -> known.getValue().isInstance(o))
+          .map(Entry::getKey)
+          .findFirst()
+          .orElseThrow();
+    }
+
+    @Override
+    public String idFromValueAndType(Object o, Class<?> aClass) {
+      return idFromValue(o);
+    }
+
+    @Override
+    public JavaType typeFromId(DatabindContext context, String id) throws IOException {
+      final var clazz = knownIds.get(id);
+      return clazz == null ? null : context.constructType(clazz);
+    }
+  }
+
+  final class UnloadFilterResolver extends StdTypeResolverBuilder {
+    @Override
+    public TypeDeserializer buildTypeDeserializer(
+        DeserializationConfig config, JavaType baseType, Collection<NamedType> subtypes) {
+      return useForType(baseType) ? super.buildTypeDeserializer(config, baseType, subtypes) : null;
+    }
+
+    @Override
+    public TypeSerializer buildTypeSerializer(
+        SerializationConfig config, JavaType baseType, Collection<NamedType> subtypes) {
+      return useForType(baseType) ? super.buildTypeSerializer(config, baseType, subtypes) : null;
+    }
+
+    public boolean useForType(JavaType t) {
+      return t.isJavaLangObject();
+    }
+  }
+
+  /**
+   * Build an equivalent filter out of primitive components
+   *
+   * @param visitor the primitives to use
+   * @param <T> the resulting filter type
+   * @return the resulting filter
+   */
+  <T> T convert(Visitor<T> visitor);
+}

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/UnloadFilterProvider.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/UnloadFilterProvider.java
@@ -1,0 +1,10 @@
+package ca.on.oicr.gsi.vidarr;
+
+import ca.on.oicr.gsi.Pair;
+import java.util.stream.Stream;
+
+/** A target that stores unloaded data */
+public interface UnloadFilterProvider {
+  /** The filter types that can be decoded and their JSON <tt>type</tt> property */
+  Stream<Pair<String, Class<? extends UnloadFilter>>> types();
+}

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/UnloadTextSelector.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/UnloadTextSelector.java
@@ -1,0 +1,129 @@
+package ca.on.oicr.gsi.vidarr;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ValueNode;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * An unload filter a JSON value that comes in two forms:
+ *
+ * <ul>
+ *   <li>a string for a direct match
+ *   <li>an array of strings for a "any in set" match
+ * </ul>
+ */
+@JsonDeserialize(using = UnloadTextSelector.JacksonDeserializer.class)
+@JsonSerialize(using = UnloadTextSelector.JacksonSerializer.class)
+public abstract class UnloadTextSelector {
+  public static final class JacksonDeserializer extends JsonDeserializer<UnloadTextSelector> {
+
+    @Override
+    public UnloadTextSelector deserialize(
+        JsonParser jsonParser, DeserializationContext deserializationContext)
+        throws IOException, JsonProcessingException {
+      final var tree = jsonParser.readValueAsTree();
+      if (tree.isValueNode() && ((ValueNode) tree).isTextual()) {
+        return of(((ValueNode) tree).asText());
+      }
+      if (tree.isArray()) {
+        final var values = new TreeSet<String>();
+        for (final var child : ((ArrayNode) tree)) {
+          if (child.isValueNode() && child.isTextual()) {
+            values.add(child.asText());
+          } else {
+            throw new IllegalArgumentException("Non-string element in array unload filter array.");
+          }
+        }
+        return of(values);
+      }
+      throw new IllegalArgumentException("JSON value is not valid unload filter.");
+    }
+  }
+
+  public static final class JacksonSerializer extends JsonSerializer<UnloadTextSelector> {
+
+    @Override
+    public void serialize(
+        UnloadTextSelector filter,
+        JsonGenerator jsonGenerator,
+        SerializerProvider serializerProvider)
+        throws IOException {
+      filter.toJson(jsonGenerator);
+    }
+  }
+
+  /**
+   * Create a new unload filter for a fixed string
+   *
+   * @param value the string to match
+   */
+  public static UnloadTextSelector of(String value) {
+    return new UnloadTextSelector() {
+
+      @Override
+      public Stream<String> stream() {
+        return Stream.of(value);
+      }
+
+      @Override
+      protected void toJson(JsonGenerator jsonGenerator) throws IOException {
+        jsonGenerator.writeString(value);
+      }
+    };
+  }
+
+  /**
+   * Create a new unload filter from a collection of items
+   *
+   * @param values the items to match
+   */
+  public static UnloadTextSelector of(Collection<String> values) {
+    return of(values.stream());
+  }
+
+  /**
+   * Create a new unload filter from a collection of items
+   *
+   * @param values the items to match
+   */
+  public static UnloadTextSelector of(Stream<String> values) {
+    return new UnloadTextSelector() {
+      private final Set<String> items = values.collect(Collectors.toCollection(TreeSet::new));
+
+      @Override
+      public Stream<String> stream() {
+        return items.stream();
+      }
+
+      @Override
+      protected void toJson(JsonGenerator jsonGenerator) throws IOException {
+        jsonGenerator.writeStartArray();
+        for (final var item : items) {
+          jsonGenerator.writeString(item);
+        }
+        jsonGenerator.writeEndArray();
+      }
+    };
+  }
+
+  private UnloadTextSelector() {}
+
+  /** Get all values in this filter */
+  public abstract Stream<String> stream();
+
+  protected abstract void toJson(JsonGenerator jsonGenerator) throws IOException;
+}

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadFilterAnalysisId.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadFilterAnalysisId.java
@@ -1,0 +1,22 @@
+package ca.on.oicr.gsi.vidarr.api;
+
+import ca.on.oicr.gsi.vidarr.UnloadFilter;
+import ca.on.oicr.gsi.vidarr.UnloadTextSelector;
+
+public final class UnloadFilterAnalysisId implements UnloadFilter {
+
+  private UnloadTextSelector id;
+
+  @Override
+  public <T> T convert(Visitor<T> visitor) {
+    return visitor.analysisId(id.stream());
+  }
+
+  public UnloadTextSelector getId() {
+    return id;
+  }
+
+  public void setId(UnloadTextSelector id) {
+    this.id = id;
+  }
+}

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadFilterAnd.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadFilterAnd.java
@@ -1,0 +1,22 @@
+package ca.on.oicr.gsi.vidarr.api;
+
+import ca.on.oicr.gsi.vidarr.UnloadFilter;
+import java.util.List;
+
+public final class UnloadFilterAnd implements UnloadFilter {
+
+  private List<UnloadFilter> filters;
+
+  @Override
+  public <T> T convert(Visitor<T> visitor) {
+    return visitor.and(filters.stream().map(f -> f.convert(visitor)));
+  }
+
+  public List<UnloadFilter> getFilters() {
+    return filters;
+  }
+
+  public void setFilters(List<UnloadFilter> filters) {
+    this.filters = filters;
+  }
+}

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadFilterCompletedAfter.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadFilterCompletedAfter.java
@@ -1,0 +1,22 @@
+package ca.on.oicr.gsi.vidarr.api;
+
+import ca.on.oicr.gsi.vidarr.UnloadFilter;
+import java.time.ZonedDateTime;
+
+public final class UnloadFilterCompletedAfter implements UnloadFilter {
+
+  private ZonedDateTime time;
+
+  @Override
+  public <T> T convert(Visitor<T> visitor) {
+    return visitor.completedAfter(time.toInstant());
+  }
+
+  public ZonedDateTime getTime() {
+    return time;
+  }
+
+  public void setTime(ZonedDateTime time) {
+    this.time = time;
+  }
+}

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadFilterExternalId.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadFilterExternalId.java
@@ -1,0 +1,31 @@
+package ca.on.oicr.gsi.vidarr.api;
+
+import ca.on.oicr.gsi.vidarr.UnloadFilter;
+import ca.on.oicr.gsi.vidarr.UnloadTextSelector;
+
+public final class UnloadFilterExternalId implements UnloadFilter {
+
+  private UnloadTextSelector id;
+  private String provider;
+
+  @Override
+  public <T> T convert(Visitor<T> visitor) {
+    return visitor.externalKey(provider, id.stream());
+  }
+
+  public UnloadTextSelector getId() {
+    return id;
+  }
+
+  public String getProvider() {
+    return provider;
+  }
+
+  public void setId(UnloadTextSelector id) {
+    this.id = id;
+  }
+
+  public void setProvider(String provider) {
+    this.provider = provider;
+  }
+}

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadFilterExternalProvider.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadFilterExternalProvider.java
@@ -1,0 +1,22 @@
+package ca.on.oicr.gsi.vidarr.api;
+
+import ca.on.oicr.gsi.vidarr.UnloadFilter;
+import ca.on.oicr.gsi.vidarr.UnloadTextSelector;
+
+public final class UnloadFilterExternalProvider implements UnloadFilter {
+
+  private UnloadTextSelector providers;
+
+  @Override
+  public <T> T convert(Visitor<T> visitor) {
+    return visitor.externalKey(providers.stream());
+  }
+
+  public UnloadTextSelector getProviders() {
+    return providers;
+  }
+
+  public void setProviders(UnloadTextSelector providers) {
+    this.providers = providers;
+  }
+}

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadFilterLastSubmittedAfter.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadFilterLastSubmittedAfter.java
@@ -1,0 +1,22 @@
+package ca.on.oicr.gsi.vidarr.api;
+
+import ca.on.oicr.gsi.vidarr.UnloadFilter;
+import java.time.ZonedDateTime;
+
+public final class UnloadFilterLastSubmittedAfter implements UnloadFilter {
+
+  private ZonedDateTime time;
+
+  @Override
+  public <T> T convert(Visitor<T> visitor) {
+    return visitor.lastSubmittedAfter(time.toInstant());
+  }
+
+  public ZonedDateTime getTime() {
+    return time;
+  }
+
+  public void setTime(ZonedDateTime time) {
+    this.time = time;
+  }
+}

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadFilterNot.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadFilterNot.java
@@ -1,0 +1,21 @@
+package ca.on.oicr.gsi.vidarr.api;
+
+import ca.on.oicr.gsi.vidarr.UnloadFilter;
+
+public final class UnloadFilterNot implements UnloadFilter {
+
+  private UnloadFilter filter;
+
+  @Override
+  public <T> T convert(Visitor<T> visitor) {
+    return visitor.not(filter.convert(visitor));
+  }
+
+  public UnloadFilter getFilter() {
+    return filter;
+  }
+
+  public void setFilter(UnloadFilter filter) {
+    this.filter = filter;
+  }
+}

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadFilterOr.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadFilterOr.java
@@ -1,0 +1,22 @@
+package ca.on.oicr.gsi.vidarr.api;
+
+import ca.on.oicr.gsi.vidarr.UnloadFilter;
+import java.util.List;
+
+public final class UnloadFilterOr implements UnloadFilter {
+
+  private List<UnloadFilter> filters;
+
+  @Override
+  public <T> T convert(Visitor<T> visitor) {
+    return visitor.or(filters.stream().map(f -> f.convert(visitor)));
+  }
+
+  public List<UnloadFilter> getFilters() {
+    return filters;
+  }
+
+  public void setFilters(List<UnloadFilter> filters) {
+    this.filters = filters;
+  }
+}

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadFilterWorkflowId.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadFilterWorkflowId.java
@@ -1,0 +1,22 @@
+package ca.on.oicr.gsi.vidarr.api;
+
+import ca.on.oicr.gsi.vidarr.UnloadFilter;
+import ca.on.oicr.gsi.vidarr.UnloadTextSelector;
+
+public final class UnloadFilterWorkflowId implements UnloadFilter {
+
+  private UnloadTextSelector id;
+
+  @Override
+  public <T> T convert(Visitor<T> visitor) {
+    return visitor.workflowId(id.stream());
+  }
+
+  public UnloadTextSelector getId() {
+    return id;
+  }
+
+  public void setId(UnloadTextSelector id) {
+    this.id = id;
+  }
+}

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadFilterWorkflowName.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadFilterWorkflowName.java
@@ -1,0 +1,22 @@
+package ca.on.oicr.gsi.vidarr.api;
+
+import ca.on.oicr.gsi.vidarr.UnloadFilter;
+import ca.on.oicr.gsi.vidarr.UnloadTextSelector;
+
+public final class UnloadFilterWorkflowName implements UnloadFilter {
+
+  private UnloadTextSelector name;
+
+  @Override
+  public <T> T convert(Visitor<T> visitor) {
+    return visitor.workflowName(name.stream());
+  }
+
+  public UnloadTextSelector getName() {
+    return name;
+  }
+
+  public void setName(UnloadTextSelector name) {
+    this.name = name;
+  }
+}

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadFilterWorkflowRunId.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadFilterWorkflowRunId.java
@@ -1,0 +1,22 @@
+package ca.on.oicr.gsi.vidarr.api;
+
+import ca.on.oicr.gsi.vidarr.UnloadFilter;
+import ca.on.oicr.gsi.vidarr.UnloadTextSelector;
+
+public final class UnloadFilterWorkflowRunId implements UnloadFilter {
+
+  private UnloadTextSelector id;
+
+  @Override
+  public <T> T convert(Visitor<T> visitor) {
+    return visitor.workflowRunId(id.stream());
+  }
+
+  public UnloadTextSelector getId() {
+    return id;
+  }
+
+  public void setId(UnloadTextSelector id) {
+    this.id = id;
+  }
+}

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadRequest.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadRequest.java
@@ -1,0 +1,26 @@
+package ca.on.oicr.gsi.vidarr.api;
+
+import ca.on.oicr.gsi.vidarr.UnloadFilter;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UnloadRequest {
+  private UnloadFilter filter;
+  private boolean recursive;
+
+  public UnloadFilter getFilter() {
+    return filter;
+  }
+
+  public boolean isRecursive() {
+    return recursive;
+  }
+
+  public void setFilter(UnloadFilter filter) {
+    this.filter = filter;
+  }
+
+  public void setRecursive(boolean recursive) {
+    this.recursive = recursive;
+  }
+}

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadResponse.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadResponse.java
@@ -1,0 +1,16 @@
+package ca.on.oicr.gsi.vidarr.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class UnloadResponse {
+  private String id;
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+}

--- a/vidarr-pluginapi/src/main/java/module-info.java
+++ b/vidarr-pluginapi/src/main/java/module-info.java
@@ -1,3 +1,5 @@
+import ca.on.oicr.gsi.vidarr.UnloadFilterProvider;
+
 /**
  * The API plugins are expected to implement
  *
@@ -5,6 +7,8 @@
  * plugins are expected to provide as well as accessory data required or provided.
  */
 module ca.on.oicr.gsi.vidarr.pluginapi {
+  uses UnloadFilterProvider;
+
   exports ca.on.oicr.gsi.vidarr;
   exports ca.on.oicr.gsi.vidarr.api;
 

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseWorkflow.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseWorkflow.java
@@ -113,7 +113,7 @@ public class DatabaseWorkflow implements ActiveWorkflow<DatabaseOperation, DSLCo
         liveness.apply(dbId));
   }
 
-  private static JSONB labelsToJson(Map<String, String> labels) {
+  public static JSONB labelsToJson(Map<String, String> labels) {
     final var labelNode = JsonNodeFactory.instance.objectNode();
     for (final var label : labels.entrySet()) {
       labelNode.put(label.getKey(), label.getValue());
@@ -125,7 +125,7 @@ public class DatabaseWorkflow implements ActiveWorkflow<DatabaseOperation, DSLCo
     }
   }
 
-  private static JSONB labelsToJson(ObjectNode labels) {
+  public static JSONB labelsToJson(ObjectNode labels) {
     try {
       return JSONB.valueOf(DatabaseBackedProcessor.MAPPER.writeValueAsString(labels));
     } catch (JsonProcessingException e) {

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/dto/ServerConfiguration.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/dto/ServerConfiguration.java
@@ -20,6 +20,7 @@ public final class ServerConfiguration {
   private int port = 8080;
   private Map<String, ObjectNode> runtimeProvisioners;
   private Map<String, TargetConfiguration> targets;
+  private String unloadDirectory = ".";
   private String url;
   private Map<String, ObjectNode> workflowEngines;
 
@@ -73,6 +74,10 @@ public final class ServerConfiguration {
 
   public Map<String, TargetConfiguration> getTargets() {
     return targets;
+  }
+
+  public String getUnloadDirectory() {
+    return unloadDirectory;
   }
 
   public String getUrl() {
@@ -133,6 +138,10 @@ public final class ServerConfiguration {
 
   public void setTargets(Map<String, TargetConfiguration> targets) {
     this.targets = targets;
+  }
+
+  public void setUnloadDirectory(String unloadDirectory) {
+    this.unloadDirectory = unloadDirectory;
   }
 
   public void setUrl(String url) {

--- a/vidarr-server/src/main/java/module-info.java
+++ b/vidarr-server/src/main/java/module-info.java
@@ -2,6 +2,7 @@ import ca.on.oicr.gsi.vidarr.ConsumableResourceProvider;
 import ca.on.oicr.gsi.vidarr.InputProvisionerProvider;
 import ca.on.oicr.gsi.vidarr.OutputProvisionerProvider;
 import ca.on.oicr.gsi.vidarr.RuntimeProvisionerProvider;
+import ca.on.oicr.gsi.vidarr.UnloadFilterProvider;
 import ca.on.oicr.gsi.vidarr.WorkflowEngineProvider;
 
 module ca.on.oicr.gsi.vidarr.server {
@@ -42,5 +43,6 @@ module ca.on.oicr.gsi.vidarr.server {
   uses InputProvisionerProvider;
   uses OutputProvisionerProvider;
   uses RuntimeProvisionerProvider;
+  uses UnloadFilterProvider;
   uses WorkflowEngineProvider;
 }


### PR DESCRIPTION
This feature allows generating exports of the Vidarr database that can be
loaded into another database. The export comes in two flavours: copy and
remove. Plugins can provide mechanisms to select workflow runs matching
particular conditions and their descendants.

The extracts can be later loaded (or reloaded) into a Vidarr instance.