### PR TITLE
Add support for optional outputs

### DIFF
--- a/types.md
+++ b/types.md
@@ -110,15 +110,22 @@ _externals_, which is a list of `{"id": "`_identifier_`", "provider":
 In each case, the type of _configuration_ depends on the output type and the
 target used. The workflow's output is described in the table.
 
-| Output Type           |  Workflow Output                                                    |
-|-----------------------|---------------------------------------------------------------------|
-| `"file"`              | A single file                                                       |
-| `"files"`             | A list of files                                                     |
-| `"file-with-labels"`  | A pair of a file and a dictionary of strings                        |
-| `"files-with-labels"` | A pair of a list of files and a dictionary of strings               |
-| `"logs"`              | A single file containing text logs                                  |
-| `"quality-control"`   | A Boolean value which indicates pass/fail                           |
-| `"warehouse-records"` | A single file containing structured data to be stored in a database |
+| Output Type                    | WDL Type                                   |  Workflow Output                                                              |
+|--------------------------------|--------------------------------------------|-------------------------------------------------------------------------------|
+| `"file"`                       | `File`                                     | A single file                                                                 |
+| `"optional-file"`              | `File?`                                    | An optional single file                                                       |
+| `"files"`                      | `Array[File]+`                             | A list of files                                                               |
+| `"optional-files"`             | `Array[File]?`                             | An optional list of files                                                     |
+| `"file-with-labels"`           | `Pair[File, Map[String, String]]`          | A pair of a file and a dictionary of strings                                  |
+| `"optional-file-with-labels"`  | `Pair[File, Map[String, String]]?`         | An optional pair of a file and a dictionary of strings                        |
+| `"files-with-labels"`          | `Pair[Array[File]+, Map[String, String]]`  | A pair of a list of files and a dictionary of strings                         |
+| `"optional-files-with-labels"` | `Pair[Array[File]+, Map[String, String]]?` | An optional pair of a list of files and a dictionary of strings               |
+| `"logs"`                       | N/A                                        | A single file containing text logs                                            |
+| `"optional-logs"`              | N/A                                        | An optional single file containing text logs                                  |
+| `"quality-control"`            | `Boolean`                                  | A Boolean value which indicates pass/fail                                     |
+| `"optional-quality-control"`   | `Boolean?`                                 | An optional Boolean value which indicates pass/fail                           |
+| `"warehouse-records"`          | N/A                                        | A single file containing structured data to be stored in a database           |
+| `"optional-warehouse-records"` | N/A                                        | An optional single file containing structured data to be stored in a database |
 
 For the data warehouse, the plugin and workflow must be mutually aware of the
 data format.
@@ -129,6 +136,16 @@ about the contents of a file that can be used by downstream processing. For
 instance, workflow producing a FASTQ or BAM file could include a sequence
 count, so a Shesmu olive consuming this file could pick an appropriate shard
 count for a subsequent workflow.
+
+Each output type has an optional variant. If used, the workflow can decline to
+provide the output and it will not be provisioned. However, all external keys
+must be assigned somewhere, so _every_ external key _must_ be assigned to at
+least one non-optional output. This means there must be at least one
+non-optional output for a workflow. Also, using `REMAINING` on mandatory values
+has ambiguous meaning when `MANUAL` is used on optional outputs. If the
+optional was or was not present, then the external keys included in `REMAINING`
+would change dynamically. This is not permitted, so mixing these two is not
+possible.
 
 In some workflows that expand or multiplex content (_e.g_, co-cleaning,
 BCL2FASTQ), the output metadata needs to be dynamically assigned to the output

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseOutputExtractor.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseOutputExtractor.java
@@ -38,26 +38,26 @@ abstract class BaseOutputExtractor<R, E> implements OutputType.Visitor<R> {
   }
 
   @Override
-  public final R file() {
-    return handle(WorkflowOutputDataType.FILE);
+  public final R file(boolean optional) {
+    return handle(WorkflowOutputDataType.FILE, optional);
   }
 
   @Override
-  public final R fileWithLabels() {
-    return handle(WorkflowOutputDataType.FILE_WITH_LABELS);
+  public final R fileWithLabels(boolean optional) {
+    return handle(WorkflowOutputDataType.FILE_WITH_LABELS, optional);
   }
 
   @Override
-  public final R files() {
-    return handle(WorkflowOutputDataType.FILES);
+  public final R files(boolean optional) {
+    return handle(WorkflowOutputDataType.FILES, optional);
   }
 
   @Override
-  public final R filesWithLabels() {
-    return handle(WorkflowOutputDataType.FILES_WITH_LABELS);
+  public final R filesWithLabels(boolean optional) {
+    return handle(WorkflowOutputDataType.FILES_WITH_LABELS, optional);
   }
 
-  private R handle(WorkflowOutputDataType format) {
+  private R handle(WorkflowOutputDataType format, boolean optional) {
 
     if (metadata.isObject()
         && metadata.has("type")
@@ -79,6 +79,7 @@ abstract class BaseOutputExtractor<R, E> implements OutputType.Visitor<R> {
           }
           return handle(
               format,
+              optional,
               contents.get(0),
               output,
               new OutputData() {
@@ -98,6 +99,7 @@ abstract class BaseOutputExtractor<R, E> implements OutputType.Visitor<R> {
           }
           return handle(
               format,
+              optional,
               contents.get(0),
               output,
               new OutputData() {
@@ -119,6 +121,7 @@ abstract class BaseOutputExtractor<R, E> implements OutputType.Visitor<R> {
             var externalIds = mapper().treeToValue(contents.get(1), ExternalId[].class);
             return handle(
                 format,
+                optional,
                 contents.get(0),
                 output,
                 new OutputData() {
@@ -142,7 +145,11 @@ abstract class BaseOutputExtractor<R, E> implements OutputType.Visitor<R> {
   }
 
   protected abstract R handle(
-      WorkflowOutputDataType format, JsonNode metadata, JsonNode output, OutputData outputData);
+      WorkflowOutputDataType format,
+      boolean optional,
+      JsonNode metadata,
+      JsonNode output,
+      OutputData outputData);
 
   protected R invalid(String error) {
     throw new IllegalArgumentException(error);
@@ -255,8 +262,8 @@ abstract class BaseOutputExtractor<R, E> implements OutputType.Visitor<R> {
   }
 
   @Override
-  public final R logs() {
-    return handle(WorkflowOutputDataType.LOGS);
+  public final R logs(boolean optional) {
+    return handle(WorkflowOutputDataType.LOGS, optional);
   }
 
   protected abstract ObjectMapper mapper();
@@ -267,12 +274,12 @@ abstract class BaseOutputExtractor<R, E> implements OutputType.Visitor<R> {
       Map<String, Object> key, String name, OutputType type, JsonNode metadata, JsonNode output);
 
   @Override
-  public final R qualityControl() {
-    return handle(WorkflowOutputDataType.QUALITY_CONTROL);
+  public final R qualityControl(boolean optional) {
+    return handle(WorkflowOutputDataType.QUALITY_CONTROL, optional);
   }
 
   @Override
-  public final R warehouseRecords() {
-    return handle(WorkflowOutputDataType.DATAWAREHOUSE_RECORDS);
+  public final R warehouseRecords(boolean optional) {
+    return handle(WorkflowOutputDataType.DATAWAREHOUSE_RECORDS, optional);
   }
 }

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseProcessor.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseProcessor.java
@@ -466,6 +466,7 @@ public abstract class BaseProcessor<
                     .outputs()
                     .allMatch(
                         output -> {
+                          final var isOk = new AtomicBoolean(true);
                           if (result.output().has(output.name())) {
                             output
                                 .type()
@@ -476,9 +477,10 @@ public abstract class BaseProcessor<
                                         result.output().get(output.name()),
                                         activeWorkflow.metadata().get(output.name()),
                                         allIds,
-                                        remainingIds))
+                                        remainingIds,
+                                        () -> isOk.set(false)))
                                 .forEach(tasks::add);
-                            return true;
+                            return isOk.get();
                           } else {
                             return false;
                           }

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/CheckOutputCompatibility.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/CheckOutputCompatibility.java
@@ -1,0 +1,70 @@
+package ca.on.oicr.gsi.vidarr.core;
+
+import ca.on.oicr.gsi.vidarr.OutputType;
+import ca.on.oicr.gsi.vidarr.api.ExternalId;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import java.util.stream.Stream;
+
+public class CheckOutputCompatibility
+    extends BaseOutputExtractor<OutputCompatibility, OutputCompatibility> {
+
+  private final ObjectMapper mapper;
+
+  public CheckOutputCompatibility(ObjectMapper mapper, JsonNode metadata) {
+    super(null, metadata);
+    this.mapper = mapper;
+  }
+
+  @Override
+  protected OutputCompatibility handle(
+      WorkflowOutputDataType format,
+      boolean optional,
+      JsonNode metadata,
+      JsonNode output,
+      OutputData outputData) {
+    return outputData.visit(
+        new OutputDataVisitor<>() {
+          @Override
+          public OutputCompatibility all() {
+            return OutputCompatibility.INDIFFERENT;
+          }
+
+          @Override
+          public OutputCompatibility external(Stream<ExternalId> ids) {
+            return optional
+                ? OutputCompatibility.OPTIONAL_WITH_MANUAL
+                : OutputCompatibility.INDIFFERENT;
+          }
+
+          @Override
+          public OutputCompatibility remaining() {
+            return optional
+                ? OutputCompatibility.INDIFFERENT
+                : OutputCompatibility.MANDATORY_WITH_REMAINING;
+          }
+        });
+  }
+
+  @Override
+  protected ObjectMapper mapper() {
+    return mapper;
+  }
+
+  @Override
+  protected OutputCompatibility mergeChildren(Stream<OutputCompatibility> stream) {
+    return stream.reduce(OutputCompatibility::worst).orElse(OutputCompatibility.INDIFFERENT);
+  }
+
+  @Override
+  protected OutputCompatibility processChild(
+      Map<String, Object> key, String name, OutputType type, JsonNode metadata, JsonNode output) {
+    return type.apply(new CheckOutputCompatibility(mapper, metadata));
+  }
+
+  @Override
+  public OutputCompatibility unknown() {
+    return OutputCompatibility.BROKEN;
+  }
+}

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/CheckOutputType.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/CheckOutputType.java
@@ -31,7 +31,11 @@ public final class CheckOutputType extends BaseOutputExtractor<Stream<String>, S
 
   @Override
   protected Stream<String> handle(
-      WorkflowOutputDataType format, JsonNode metadata, JsonNode output, OutputData outputData) {
+      WorkflowOutputDataType format,
+      boolean optional,
+      JsonNode metadata,
+      JsonNode output,
+      OutputData outputData) {
     final var provision = target.provisionerFor(format.format());
     if (provision == null) {
       return Stream.of(

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/ExtractOutputKeys.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/ExtractOutputKeys.java
@@ -1,0 +1,82 @@
+package ca.on.oicr.gsi.vidarr.core;
+
+import ca.on.oicr.gsi.Pair;
+import ca.on.oicr.gsi.vidarr.OutputType;
+import ca.on.oicr.gsi.vidarr.api.ExternalId;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public class ExtractOutputKeys
+    extends BaseOutputExtractor<Stream<Pair<String, String>>, Stream<Pair<String, String>>> {
+
+  private final Set<Pair<String, String>> externalKeyIds;
+  private final ObjectMapper mapper;
+  private final boolean optional;
+
+  public ExtractOutputKeys(
+      ObjectMapper mapper,
+      Set<Pair<String, String>> externalKeyIds,
+      boolean optional,
+      JsonNode metadata) {
+    super(null, metadata);
+    this.mapper = mapper;
+    this.externalKeyIds = externalKeyIds;
+    this.optional = optional;
+  }
+
+  @Override
+  protected Stream<Pair<String, String>> handle(
+      WorkflowOutputDataType format,
+      boolean optional,
+      JsonNode metadata,
+      JsonNode output,
+      OutputData outputData) {
+    if (optional == this.optional) {
+      return outputData.visit(
+          new OutputDataVisitor<Stream<Pair<String, String>>>() {
+            @Override
+            public Stream<Pair<String, String>> all() {
+              return externalKeyIds.stream();
+            }
+
+            @Override
+            public Stream<Pair<String, String>> external(Stream<ExternalId> ids) {
+              return ids.map(id -> new Pair<>(id.getProvider(), id.getId()));
+            }
+
+            @Override
+            public Stream<Pair<String, String>> remaining() {
+              return externalKeyIds.stream();
+            }
+          });
+    } else {
+      return Stream.empty();
+    }
+  }
+
+  @Override
+  protected ObjectMapper mapper() {
+    return mapper;
+  }
+
+  @Override
+  protected Stream<Pair<String, String>> mergeChildren(
+      Stream<Stream<Pair<String, String>>> stream) {
+    return stream.flatMap(Function.identity());
+  }
+
+  @Override
+  protected Stream<Pair<String, String>> processChild(
+      Map<String, Object> key, String name, OutputType type, JsonNode metadata, JsonNode output) {
+    return type.apply(new ExtractOutputKeys(mapper, externalKeyIds, optional, metadata));
+  }
+
+  @Override
+  public Stream<Pair<String, String>> unknown() {
+    throw new UnsupportedOperationException("Cannot extract keys from unknown metadata");
+  }
+}

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/OutputCompatibility.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/OutputCompatibility.java
@@ -1,0 +1,34 @@
+package ca.on.oicr.gsi.vidarr.core;
+
+public enum OutputCompatibility {
+  INDIFFERENT,
+  OPTIONAL_WITH_MANUAL,
+  MANDATORY_WITH_REMAINING,
+  BROKEN;
+
+  public OutputCompatibility worst(OutputCompatibility other) {
+    switch (this) {
+      case BROKEN:
+        return BROKEN;
+      case INDIFFERENT:
+        return other;
+      case OPTIONAL_WITH_MANUAL:
+        switch (other) {
+          case BROKEN:
+          case MANDATORY_WITH_REMAINING:
+            return BROKEN;
+          default:
+            return this;
+        }
+      case MANDATORY_WITH_REMAINING:
+        switch (other) {
+          case BROKEN:
+          case OPTIONAL_WITH_MANUAL:
+            return BROKEN;
+          default:
+            return this;
+        }
+    }
+    return BROKEN;
+  }
+}

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/PreparePreflightChecks.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/PreparePreflightChecks.java
@@ -35,7 +35,11 @@ final class PreparePreflightChecks extends BaseOutputExtractor<Boolean, Boolean>
 
   @Override
   protected Boolean handle(
-      WorkflowOutputDataType format, JsonNode metadata, JsonNode output, OutputData outputData) {
+      WorkflowOutputDataType format,
+      boolean optional,
+      JsonNode metadata,
+      JsonNode output,
+      OutputData outputData) {
     final var handler = target.provisionerFor(format.format());
     if (handler == null) {
       return false;

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/OutputType.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/OutputType.java
@@ -57,22 +57,22 @@ public abstract class OutputType {
   public interface Visitor<T> {
 
     /** The output is a single files */
-    default T file() {
+    default T file(boolean optional) {
       return unknown();
     }
 
     /** The output is a pair of a single files and a dictionary of labels */
-    default T fileWithLabels() {
+    default T fileWithLabels(boolean optional) {
       return unknown();
     }
 
     /** The output is a list of files */
-    default T files() {
+    default T files(boolean optional) {
       return unknown();
     }
 
     /** The output is a pair of a list of files and a dictionary of labels */
-    default T filesWithLabels() {
+    default T filesWithLabels(boolean optional) {
       return unknown();
     }
 
@@ -87,12 +87,12 @@ public abstract class OutputType {
     }
 
     /** The output is logs */
-    default T logs() {
+    default T logs(boolean optional) {
       return unknown();
     }
 
     /** The output is quality control information */
-    default T qualityControl() {
+    default T qualityControl(boolean optional) {
       return unknown();
     }
 
@@ -105,7 +105,7 @@ public abstract class OutputType {
     T unknown();
 
     /** The output is data warehouse records */
-    default T warehouseRecords() {
+    default T warehouseRecords(boolean optional) {
       return unknown();
     }
   }
@@ -139,6 +139,20 @@ public abstract class OutputType {
             return OutputType.UNKNOWN;
           case "warehouse-records":
             return OutputType.WAREHOUSE_RECORDS;
+          case "optional-file":
+            return OutputType.FILE_OPTIONAL;
+          case "optional-files":
+            return OutputType.FILES_OPTIONAL;
+          case "optional-file-with-labels":
+            return OutputType.FILE_WITH_LABELS_OPTIONAL;
+          case "optional-files-with-labels":
+            return OutputType.FILES_WITH_LABELS_OPTIONAL;
+          case "optional-logs":
+            return OutputType.LOGS_OPTIONAL;
+          case "optional-quality-control":
+            return OutputType.QUALITY_CONTROL_OPTIONAL;
+          case "optional-warehouse-records":
+            return OutputType.WAREHOUSE_RECORDS_OPTIONAL;
           default:
             throw new IllegalArgumentException("Unknown output type: " + str);
         }
@@ -191,23 +205,25 @@ public abstract class OutputType {
           .apply(
               new Visitor<Printer>() {
                 @Override
-                public Printer file() {
-                  return g -> g.writeString("file");
+                public Printer file(boolean optional) {
+                  return g -> g.writeString(optional ? "optional-file" : "file");
                 }
 
                 @Override
-                public Printer fileWithLabels() {
-                  return g -> g.writeString("file-with-labels");
+                public Printer fileWithLabels(boolean optional) {
+                  return g ->
+                      g.writeString(optional ? "optional-file-with-labels" : "file-with-labels");
                 }
 
                 @Override
-                public Printer files() {
-                  return g -> g.writeString("files");
+                public Printer files(boolean optional) {
+                  return g -> g.writeString(optional ? "optional-files" : "files");
                 }
 
                 @Override
-                public Printer filesWithLabels() {
-                  return g -> g.writeString("files-with-labels");
+                public Printer filesWithLabels(boolean optional) {
+                  return g ->
+                      g.writeString(optional ? "optional-files-with-labels" : "files-with-labels");
                 }
 
                 @Override
@@ -236,13 +252,14 @@ public abstract class OutputType {
                 }
 
                 @Override
-                public Printer logs() {
-                  return g -> g.writeString("logs");
+                public Printer logs(boolean optional) {
+                  return g -> g.writeString(optional ? "optional-logs" : "logs");
                 }
 
                 @Override
-                public Printer qualityControl() {
-                  return g -> g.writeString("quality-control");
+                public Printer qualityControl(boolean optional) {
+                  return g ->
+                      g.writeString(optional ? "optioal-quality-control" : "quality-control");
                 }
 
                 @Override
@@ -251,8 +268,9 @@ public abstract class OutputType {
                 }
 
                 @Override
-                public Printer warehouseRecords() {
-                  return g -> g.writeString("warehouse-records");
+                public Printer warehouseRecords(boolean optional) {
+                  return g ->
+                      g.writeString(optional ? "optional-warehouse-records" : "warehouse-records");
                 }
               })
           .print(jsonGenerator);
@@ -303,7 +321,15 @@ public abstract class OutputType {
       new OutputType() {
         @Override
         public <T> T apply(Visitor<T> visitor) {
-          return visitor.file();
+          return visitor.file(false);
+        }
+      };
+  /** The output is an optional single file */
+  public static final OutputType FILE_OPTIONAL =
+      new OutputType() {
+        @Override
+        public <T> T apply(Visitor<T> visitor) {
+          return visitor.file(true);
         }
       };
   /** The output is a collection files that should have identical metadata */
@@ -311,7 +337,15 @@ public abstract class OutputType {
       new OutputType() {
         @Override
         public <T> T apply(Visitor<T> visitor) {
-          return visitor.files();
+          return visitor.files(false);
+        }
+      };
+  /** The output is an optional collection files that should have identical metadata */
+  public static final OutputType FILES_OPTIONAL =
+      new OutputType() {
+        @Override
+        public <T> T apply(Visitor<T> visitor) {
+          return visitor.files(true);
         }
       };
   /**
@@ -322,7 +356,18 @@ public abstract class OutputType {
       new OutputType() {
         @Override
         public <T> T apply(Visitor<T> visitor) {
-          return visitor.filesWithLabels();
+          return visitor.filesWithLabels(false);
+        }
+      };
+  /**
+   * The output is an optional collection files with workflow-derived labels that should have
+   * identical metadata
+   */
+  public static final OutputType FILES_WITH_LABELS_OPTIONAL =
+      new OutputType() {
+        @Override
+        public <T> T apply(Visitor<T> visitor) {
+          return visitor.filesWithLabels(true);
         }
       };
   /** The output is a single files with workflow-derived labels */
@@ -330,7 +375,15 @@ public abstract class OutputType {
       new OutputType() {
         @Override
         public <T> T apply(Visitor<T> visitor) {
-          return visitor.fileWithLabels();
+          return visitor.fileWithLabels(false);
+        }
+      };
+  /** The output is an optional single files with workflow-derived labels */
+  public static final OutputType FILE_WITH_LABELS_OPTIONAL =
+      new OutputType() {
+        @Override
+        public <T> T apply(Visitor<T> visitor) {
+          return visitor.fileWithLabels(true);
         }
       };
   /** The output is logs */
@@ -338,7 +391,15 @@ public abstract class OutputType {
       new OutputType() {
         @Override
         public <T> T apply(Visitor<T> visitor) {
-          return visitor.logs();
+          return visitor.logs(false);
+        }
+      };
+  /** The output is optional logs */
+  public static final OutputType LOGS_OPTIONAL =
+      new OutputType() {
+        @Override
+        public <T> T apply(Visitor<T> visitor) {
+          return visitor.logs(true);
         }
       };
   /** The output is quality control information */
@@ -346,7 +407,15 @@ public abstract class OutputType {
       new OutputType() {
         @Override
         public <T> T apply(Visitor<T> visitor) {
-          return visitor.qualityControl();
+          return visitor.qualityControl(false);
+        }
+      };
+  /** The output is optional quality control information */
+  public static final OutputType QUALITY_CONTROL_OPTIONAL =
+      new OutputType() {
+        @Override
+        public <T> T apply(Visitor<T> visitor) {
+          return visitor.qualityControl(true);
         }
       };
   /** The output is unknown or an error */
@@ -362,7 +431,15 @@ public abstract class OutputType {
       new OutputType() {
         @Override
         public <T> T apply(Visitor<T> visitor) {
-          return visitor.warehouseRecords();
+          return visitor.warehouseRecords(false);
+        }
+      };
+  /** The output is optional data warehouse records */
+  public static final OutputType WAREHOUSE_RECORDS_OPTIONAL =
+      new OutputType() {
+        @Override
+        public <T> T apply(Visitor<T> visitor) {
+          return visitor.warehouseRecords(true);
         }
       };
 


### PR DESCRIPTION
This allows optional outputs in the results with the condition that any
external keys associated with those optional outputs are also associated with a
mandatory output. The output keys were not being checked at all, so this adds
additional checks.