### PR TITLE
Fix read locking bug

### DIFF
--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
@@ -1265,7 +1265,6 @@ public final class Main implements ServerConfig {
     exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/json");
     exchange.setStatusCode(StatusCodes.OK);
     final var endTime = OffsetDateTime.now();
-    epochLock.readLock().lock();
     try (final var output = MAPPER_FACTORY.createGenerator(exchange.getOutputStream())) {
       InFlightCountsByWorkflow counts = maxInFlightPerWorkflow.getCountsByWorkflow();
       output.writeStartObject();


### PR DESCRIPTION
Do not get the read lock when fetching max-in-flight data because:

- the max-in-flight endpoint does not read data protected by this lock
- the endpoint did not release the lock, causing deadlock in mixed read/write scenarios