### PR TITLE
Pass through stderr from calculate script

### DIFF
--- a/vidarr-cli/src/main/java/ca/on/oicr/gsi/vidarr/cli/TestValidatorScript.java
+++ b/vidarr-cli/src/main/java/ca/on/oicr/gsi/vidarr/cli/TestValidatorScript.java
@@ -66,6 +66,7 @@ public final class TestValidatorScript extends TestValidator {
             System.err.printf("%s: [%s] Calculating output to %s...%n", id, Instant.now(), output);
             final var calculateProcess =
                 new ProcessBuilder()
+                    .inheritIO()
                     .directory(calculateDir.toFile())
                     .command(calculateScript.toAbsolutePath().toString(), calculateDir.toString())
                     .redirectOutput(output)


### PR DESCRIPTION
Send stderr generated by the calculate script to the test program's stderr.
Stdout will still be captured.