### PR TITLE
Add index to `analysis_external_id` table

### DIFF
--- a/vidarr-server/src/main/resources/db/migration/V0007__analysisext_idx.sql
+++ b/vidarr-server/src/main/resources/db/migration/V0007__analysisext_idx.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS analysis_external_id_analysis_id;
+CREATE INDEX analysis_external_id_analysis_id ON analysis_external_id(analysis_id);


### PR DESCRIPTION
This index helps the provenance query and reduces the estimated total query
cost to 1.6% of its original value.