### PR TITLE
Remove version export restriction

### DIFF
--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
@@ -1517,14 +1517,8 @@ public final class Main implements ServerConfig {
                       .join(WORKFLOW_DEFINITION)
                       .on(WORKFLOW_VERSION.WORKFLOW_DEFINITION.eq(WORKFLOW_DEFINITION.ID)))
               .where(
-                  WORKFLOW_VERSION
-                      .NAME
-                      .in(DSL.select(WORKFLOW.NAME).from(WORKFLOW).where(WORKFLOW.IS_ACTIVE))
-                      .and(
-                          WORKFLOW_VERSION.MODIFIED.eq(
-                              DSL.select(DSL.max(workflowVersionAlias.MODIFIED))
-                                  .from(workflowVersionAlias)
-                                  .where(workflowVersionAlias.NAME.eq(WORKFLOW_VERSION.NAME)))))
+                  WORKFLOW_VERSION.NAME.in(
+                      DSL.select(WORKFLOW.NAME).from(WORKFLOW).where(WORKFLOW.IS_ACTIVE)))
               .fetchOptional()
               .orElseThrow()
               .value1();


### PR DESCRIPTION
The `/api/workflows` endpoint only exported the latest version of a workflow to
reduce the amount of clutter in Shesmu. This is a bad idea for multiple
reasons:

- migration creates new old workflows, pushing the current workflow off the list
- the author of a new workflow might not want to immediately move all olives to the new version

So, I am removing this restriction and exporting all workflows. If there needs
to be export control per version, this can be added later.