### PR TITLE
Improve PAM input label

### DIFF
--- a/vidarr-prometheus/src/main/java/ca/on/oicr/gsi/vidarr/prometheus/PrometheusAlertManagerConsumableResource.java
+++ b/vidarr-prometheus/src/main/java/ca/on/oicr/gsi/vidarr/prometheus/PrometheusAlertManagerConsumableResource.java
@@ -80,7 +80,7 @@ public class PrometheusAlertManagerConsumableResource implements ConsumableResou
 
   @Override
   public Optional<Pair<String, BasicType>> inputFromSubmitter() {
-    return Optional.of(new Pair<>("required_services", BasicType.STRING.asList()));
+    return Optional.of(new Pair<>("stop_if_autoinhibits_firing", BasicType.STRING.asList()));
   }
 
   @Override


### PR DESCRIPTION
If the PAM plugin is configured, each workflow run submission needs to contain this label-value pair. The initial "required_services" label makes it sound like the value should be a service that needs to be up, but alerts instead tend to fire if something is down. This attempts to make it clearer what sort of value (AutoInhibit alert labels) should be provided.