### PR TITLE
Move dependency-plugin config outside <executions>

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,17 +231,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>2.8</version>
-        <executions>
-          <execution>
-            <id>copy-dependencies</id>
-            <goals>
-              <goal>copy-dependencies</goal>
-            </goals>
-            <configuration>
-              <includeScope>runtime</includeScope>
-            </configuration>
-          </execution>
-        </executions>
+        <configuration>
+          <includeScope>runtime</includeScope>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
  * As per maven-dependency-plugin documentation:
    "If you intend to configure this goal for
    execution on the command line [...] you must
    not put the configuration inside the executions
    tag
    * Our current deploy plan uses command-line
      execution