### PR TITLE
[GP-2743] Reduce magic strings

### DIFF
--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/InputType.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/InputType.java
@@ -21,6 +21,30 @@ import java.util.stream.StreamSupport;
 @JsonSerialize(using = InputType.JacksonSerializer.class)
 @JsonDeserialize(using = InputType.JacksonDeserializer.class)
 public abstract class InputType {
+  private static final String STR_BOOLEAN = "boolean",
+      STR_DATE = "date",
+      STR_DIRECTORY = "directory",
+      STR_FILE = "file",
+      STR_FLOATING = "floating",
+      STR_INTEGER = "integer",
+      STR_JSON = "json",
+      STR_STRING = "string",
+      STR_DICTIONARY = "dictionary",
+      STR_OBJECT = "object",
+      STR_PAIR = "pair",
+      STR_TAGGED_UNION = "tagged-union",
+      STR_TUPLE = "tuple",
+      STR_LIST = "list",
+      STR_OPTIONAL = "optional",
+      STR_IS = "is",
+      STR_KEY = "key",
+      STR_VALUE = "value",
+      STR_INNER = "inner",
+      STR_FIELDS = "fields",
+      STR_LEFT = "left",
+      STR_RIGHT = "right",
+      STR_OPTIONS = "options",
+      STR_ELEMENTS = "elements";
   /**
    * Convert an input type into another value
    *
@@ -145,78 +169,79 @@ public abstract class InputType {
       if (node.isValueNode() && ((ValueNode) node).isTextual()) {
         final var str = ((ValueNode) node).asText();
         switch (str) {
-          case "boolean":
+          case STR_BOOLEAN:
             return InputType.BOOLEAN;
-          case "date":
+          case STR_DATE:
             return InputType.DATE;
-          case "directory":
+          case STR_DIRECTORY:
             return InputType.DIRECTORY;
-          case "file":
+          case STR_FILE:
             return InputType.FILE;
-          case "floating":
+          case STR_FLOATING:
             return InputType.FLOAT;
-          case "integer":
+          case STR_INTEGER:
             return InputType.INTEGER;
-          case "json":
+          case STR_JSON:
             return InputType.JSON;
-          case "string":
+          case STR_STRING:
             return InputType.STRING;
           default:
             throw new IllegalArgumentException("Unknown input type: " + str);
         }
       } else if (node.isObject() && node instanceof ObjectNode) {
         final var obj = (ObjectNode) node;
-        if (obj.has("is") && obj.get("is").isTextual()) {
-          switch (obj.get("is").asText()) {
-            case "dictionary":
-              if (!obj.has("key")) {
+        if (obj.has(STR_IS) && obj.get(STR_IS).isTextual()) {
+          switch (obj.get(STR_IS).asText()) {
+            case STR_DICTIONARY:
+              if (!obj.has(STR_KEY)) {
                 throw new IllegalArgumentException("Missing 'key' in dictionary.");
               }
-              if (!obj.has("value")) {
+              if (!obj.has(STR_VALUE)) {
                 throw new IllegalArgumentException("Missing 'value' in dictionary.");
               }
-              return dictionary(deserialize(obj.get("key")), deserialize(obj.get("value")));
-            case "list":
-              if (!obj.has("inner")) {
+              return dictionary(deserialize(obj.get(STR_KEY)), deserialize(obj.get(STR_VALUE)));
+            case STR_LIST:
+              if (!obj.has(STR_INNER)) {
                 throw new IllegalArgumentException("Missing 'inner' in list.");
               }
-              return deserialize(obj.get("inner")).asList();
-            case "object":
-              if (!obj.has("fields")) {
+              return deserialize(obj.get(STR_INNER)).asList();
+            case STR_OBJECT:
+              if (!obj.has(STR_FIELDS)) {
                 throw new IllegalArgumentException("Missing 'fields' in object.");
               }
               return object(
                   StreamSupport.stream(
-                          Spliterators.spliteratorUnknownSize(obj.get("fields").fields(), 0), false)
+                          Spliterators.spliteratorUnknownSize(obj.get(STR_FIELDS).fields(), 0),
+                          false)
                       .map(e -> new Pair<>(e.getKey(), deserialize(e.getValue()))));
-            case "optional":
-              if (!obj.has("inner")) {
+            case STR_OPTIONAL:
+              if (!obj.has(STR_INNER)) {
                 throw new IllegalArgumentException("Missing 'inner' in optional.");
               }
-              return deserialize(obj.get("inner")).asOptional();
-            case "pair":
-              if (!obj.has("left")) {
+              return deserialize(obj.get(STR_INNER)).asOptional();
+            case STR_PAIR:
+              if (!obj.has(STR_LEFT)) {
                 throw new IllegalArgumentException("Missing 'left' in pair.");
               }
-              if (!obj.has("right")) {
+              if (!obj.has(STR_RIGHT)) {
                 throw new IllegalArgumentException("Missing 'right' in pair.");
               }
-              return pair(deserialize(obj.get("left")), deserialize(obj.get("right")));
-            case "tagged-union":
-              if (!obj.has("options")) {
+              return pair(deserialize(obj.get(STR_LEFT)), deserialize(obj.get(STR_RIGHT)));
+            case STR_TAGGED_UNION:
+              if (!obj.has(STR_OPTIONS)) {
                 throw new IllegalArgumentException("Missing 'options' in tagged union.");
               }
               return taggedUnionFromPairs(
                   StreamSupport.stream(
-                          Spliterators.spliteratorUnknownSize(obj.get("options").fields(), 0),
+                          Spliterators.spliteratorUnknownSize(obj.get(STR_OPTIONS).fields(), 0),
                           false)
                       .map(e -> new Pair<>(e.getKey(), deserialize(e.getValue()))));
-            case "tuple":
-              if (!obj.has("elements")) {
+            case STR_TUPLE:
+              if (!obj.has(STR_ELEMENTS)) {
                 throw new IllegalArgumentException("Missing 'elements' in tuple.");
               }
               return tuple(
-                  StreamSupport.stream(obj.get("elements").spliterator(), false)
+                  StreamSupport.stream(obj.get(STR_ELEMENTS).spliterator(), false)
                       .map(this::deserialize)
                       .toArray(InputType[]::new));
             default:
@@ -246,12 +271,12 @@ public abstract class InputType {
               new Visitor<Printer>() {
                 @Override
                 public Printer bool() {
-                  return g -> g.writeString("boolean");
+                  return g -> g.writeString(STR_BOOLEAN);
                 }
 
                 @Override
                 public Printer date() {
-                  return g -> g.writeString("date");
+                  return g -> g.writeString(STR_DATE);
                 }
 
                 @Override
@@ -260,10 +285,10 @@ public abstract class InputType {
                   final var printValue = value.apply(this);
                   return g -> {
                     g.writeStartObject();
-                    g.writeStringField("is", "dictionary");
-                    g.writeFieldName("key");
+                    g.writeStringField(STR_IS, STR_DICTIONARY);
+                    g.writeFieldName(STR_KEY);
                     printKey.print(g);
-                    g.writeFieldName("value");
+                    g.writeFieldName(STR_VALUE);
                     printValue.print(g);
                     g.writeEndObject();
                   };
@@ -271,27 +296,27 @@ public abstract class InputType {
 
                 @Override
                 public Printer directory() {
-                  return g -> g.writeString("directory");
+                  return g -> g.writeString(STR_DIRECTORY);
                 }
 
                 @Override
                 public Printer file() {
-                  return g -> g.writeString("file");
+                  return g -> g.writeString(STR_FILE);
                 }
 
                 @Override
                 public Printer floating() {
-                  return g -> g.writeString("floating");
+                  return g -> g.writeString(STR_FLOATING);
                 }
 
                 @Override
                 public Printer integer() {
-                  return g -> g.writeString("integer");
+                  return g -> g.writeString(STR_INTEGER);
                 }
 
                 @Override
                 public Printer json() {
-                  return g -> g.writeString("json");
+                  return g -> g.writeString(STR_JSON);
                 }
 
                 @Override
@@ -299,8 +324,8 @@ public abstract class InputType {
                   final var printInner = inner.apply(this);
                   return g -> {
                     g.writeStartObject();
-                    g.writeStringField("is", "list");
-                    g.writeFieldName("inner");
+                    g.writeStringField(STR_IS, STR_LIST);
+                    g.writeFieldName(STR_INNER);
                     printInner.print(g);
                     g.writeEndObject();
                   };
@@ -314,8 +339,8 @@ public abstract class InputType {
                           .collect(Collectors.toList());
                   return g -> {
                     g.writeStartObject();
-                    g.writeStringField("is", "object");
-                    g.writeObjectFieldStart("fields");
+                    g.writeStringField(STR_IS, STR_OBJECT);
+                    g.writeObjectFieldStart(STR_FIELDS);
                     for (final var field : fields) {
                       g.writeFieldName(field.first());
                       field.second().print(g);
@@ -330,8 +355,8 @@ public abstract class InputType {
                   final var printInner = inner.apply(this);
                   return g -> {
                     g.writeStartObject();
-                    g.writeStringField("is", "optional");
-                    g.writeFieldName("inner");
+                    g.writeStringField(STR_IS, STR_OPTIONAL);
+                    g.writeFieldName(STR_INNER);
                     printInner.print(g);
                     g.writeEndObject();
                   };
@@ -343,10 +368,10 @@ public abstract class InputType {
                   final var printRight = right.apply(this);
                   return g -> {
                     g.writeStartObject();
-                    g.writeStringField("is", "pair");
-                    g.writeFieldName("left");
+                    g.writeStringField(STR_IS, STR_PAIR);
+                    g.writeFieldName(STR_LEFT);
                     printLeft.print(g);
-                    g.writeFieldName("right");
+                    g.writeFieldName(STR_RIGHT);
                     printRight.print(g);
                     g.writeEndObject();
                   };
@@ -354,7 +379,7 @@ public abstract class InputType {
 
                 @Override
                 public Printer string() {
-                  return g -> g.writeString("string");
+                  return g -> g.writeString(STR_STRING);
                 }
 
                 @Override
@@ -364,8 +389,8 @@ public abstract class InputType {
                           Collectors.toMap(Map.Entry::getKey, e -> e.getValue().apply(this)));
                   return g -> {
                     g.writeStartObject();
-                    g.writeStringField("is", "tagged-union");
-                    g.writeObjectFieldStart("options");
+                    g.writeStringField(STR_IS, STR_TAGGED_UNION);
+                    g.writeObjectFieldStart(STR_OPTIONS);
                     for (final var union : unions.entrySet()) {
                       g.writeFieldName(union.getKey());
                       union.getValue().print(g);
@@ -381,8 +406,8 @@ public abstract class InputType {
                       contents.map(e -> e.apply(this)).collect(Collectors.toList());
                   return g -> {
                     g.writeStartObject();
-                    g.writeStringField("is", "tuple");
-                    g.writeArrayFieldStart("elements");
+                    g.writeStringField(STR_IS, STR_TUPLE);
+                    g.writeArrayFieldStart(STR_ELEMENTS);
                     for (final var element : elements) {
                       element.print(g);
                     }

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/OutputType.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/OutputType.java
@@ -30,6 +30,25 @@ import java.util.stream.StreamSupport;
 @JsonSerialize(using = OutputType.JacksonSerializer.class)
 @JsonDeserialize(using = OutputType.JacksonDeserializer.class)
 public abstract class OutputType {
+  private static final String STR_FILE = "file",
+      STR_FILE_OPTIONAL = "optional-file",
+      STR_FILES = "files",
+      STR_FILES_OPTIONAL = "optional-files",
+      STR_FILES_WITH_LABELS = "files-with-labels",
+      STR_FILES_WITH_LABELS_OPTIONAL = "optional-files-with-labels",
+      STR_FILE_WITH_LABELS = "file-with-labels",
+      STR_FILE_WITH_LABELS_OPTIONAL = "optional-file-with-labels",
+      STR_LOGS = "logs",
+      STR_LOGS_OPTIONAL = "optional-logs",
+      STR_QUALITY_CONTROL = "quality-control",
+      STR_QUALITY_CONTROL_OPTIONAL = "optional-quality-control",
+      STR_UNKNOWN = "unknown",
+      STR_WAREHOUSE_RECORDS = "warehouse-records",
+      STR_WAREHOUSE_RECORDS_OPTIONAL = "optional-warehouse-records",
+      STR_LIST = "list",
+      STR_IS = "is",
+      STR_KEYS = "keys",
+      STR_OUTPUTS = "outputs";
   /**
    * The type of elements to used as keys when provisioning out structures
    *
@@ -123,59 +142,59 @@ public abstract class OutputType {
       if (node.isValueNode() && ((ValueNode) node).isTextual()) {
         final var str = ((ValueNode) node).asText();
         switch (str) {
-          case "file":
+          case STR_FILE:
             return OutputType.FILE;
-          case "files":
+          case STR_FILES:
             return OutputType.FILES;
-          case "file-with-labels":
+          case STR_FILE_WITH_LABELS:
             return OutputType.FILE_WITH_LABELS;
-          case "files-with-labels":
+          case STR_FILES_WITH_LABELS:
             return OutputType.FILES_WITH_LABELS;
-          case "logs":
+          case STR_LOGS:
             return OutputType.LOGS;
-          case "quality-control":
+          case STR_QUALITY_CONTROL:
             return OutputType.QUALITY_CONTROL;
-          case "unknown":
+          case STR_UNKNOWN:
             return OutputType.UNKNOWN;
-          case "warehouse-records":
+          case STR_WAREHOUSE_RECORDS:
             return OutputType.WAREHOUSE_RECORDS;
-          case "optional-file":
+          case STR_FILE_OPTIONAL:
             return OutputType.FILE_OPTIONAL;
-          case "optional-files":
+          case STR_FILES_OPTIONAL:
             return OutputType.FILES_OPTIONAL;
-          case "optional-file-with-labels":
+          case STR_FILE_WITH_LABELS_OPTIONAL:
             return OutputType.FILE_WITH_LABELS_OPTIONAL;
-          case "optional-files-with-labels":
+          case STR_FILES_WITH_LABELS_OPTIONAL:
             return OutputType.FILES_WITH_LABELS_OPTIONAL;
-          case "optional-logs":
+          case STR_LOGS_OPTIONAL:
             return OutputType.LOGS_OPTIONAL;
-          case "optional-quality-control":
+          case STR_QUALITY_CONTROL_OPTIONAL:
             return OutputType.QUALITY_CONTROL_OPTIONAL;
-          case "optional-warehouse-records":
+          case STR_WAREHOUSE_RECORDS_OPTIONAL:
             return OutputType.WAREHOUSE_RECORDS_OPTIONAL;
           default:
             throw new IllegalArgumentException("Unknown output type: " + str);
         }
       } else if (node.isObject() && node instanceof ObjectNode) {
         final var obj = (ObjectNode) node;
-        if (obj.has("is") && obj.get("is").isTextual()) {
-          switch (obj.get("is").asText()) {
-            case "list":
-              if (!obj.has("keys")) {
+        if (obj.has(STR_IS) && obj.get(STR_IS).isTextual()) {
+          switch (obj.get(STR_IS).asText()) {
+            case STR_LIST:
+              if (!obj.has(STR_KEYS)) {
                 throw new IllegalArgumentException("List is missing 'keys' property");
               }
-              if (!obj.has("outputs")) {
+              if (!obj.has(STR_OUTPUTS)) {
                 throw new IllegalArgumentException("List is missing 'outputs' property");
               }
               return list(
                   (StreamSupport.stream(
-                          Spliterators.spliteratorUnknownSize(obj.get("keys").fields(), 0), false)
+                          Spliterators.spliteratorUnknownSize(obj.get(STR_KEYS).fields(), 0), false)
                       .collect(
                           Collectors.toMap(
                               Map.Entry::getKey,
                               e -> IdentifierKey.valueOf(e.getValue().asText().toUpperCase())))),
                   (StreamSupport.stream(
-                          Spliterators.spliteratorUnknownSize(obj.get("outputs").fields(), 0),
+                          Spliterators.spliteratorUnknownSize(obj.get(STR_OUTPUTS).fields(), 0),
                           false)
                       .collect(
                           Collectors.toMap(Map.Entry::getKey, e -> deserialize(e.getValue())))));
@@ -206,43 +225,45 @@ public abstract class OutputType {
               new Visitor<Printer>() {
                 @Override
                 public Printer file(boolean optional) {
-                  return g -> g.writeString(optional ? "optional-file" : "file");
+                  return g -> g.writeString(optional ? STR_FILE_OPTIONAL : STR_FILE);
                 }
 
                 @Override
                 public Printer fileWithLabels(boolean optional) {
                   return g ->
-                      g.writeString(optional ? "optional-file-with-labels" : "file-with-labels");
+                      g.writeString(
+                          optional ? STR_FILE_WITH_LABELS_OPTIONAL : STR_FILE_WITH_LABELS);
                 }
 
                 @Override
                 public Printer files(boolean optional) {
-                  return g -> g.writeString(optional ? "optional-files" : "files");
+                  return g -> g.writeString(optional ? STR_FILES_OPTIONAL : STR_FILES);
                 }
 
                 @Override
                 public Printer filesWithLabels(boolean optional) {
                   return g ->
-                      g.writeString(optional ? "optional-files-with-labels" : "files-with-labels");
+                      g.writeString(
+                          optional ? STR_FILES_WITH_LABELS_OPTIONAL : STR_FILES_WITH_LABELS);
                 }
 
                 @Override
                 public Printer list(
                     Map<String, IdentifierKey> keys, Map<String, OutputType> outputs) {
-                  final var printOuputs =
+                  final var printOutputs =
                       outputs.entrySet().stream()
                           .collect(
                               Collectors.toMap(Map.Entry::getKey, e -> e.getValue().apply(this)));
                   return g -> {
                     g.writeStartObject();
-                    g.writeStringField("is", "list");
-                    g.writeObjectFieldStart("keys");
+                    g.writeStringField(STR_IS, STR_LIST);
+                    g.writeObjectFieldStart(STR_KEYS);
                     for (final var key : keys.entrySet()) {
                       g.writeStringField(key.getKey(), key.getValue().name().toLowerCase());
                     }
                     g.writeEndObject();
-                    g.writeObjectFieldStart("outputs");
-                    for (final var output : printOuputs.entrySet()) {
+                    g.writeObjectFieldStart(STR_OUTPUTS);
+                    for (final var output : printOutputs.entrySet()) {
                       g.writeFieldName(output.getKey());
                       output.getValue().print(g);
                     }
@@ -253,24 +274,25 @@ public abstract class OutputType {
 
                 @Override
                 public Printer logs(boolean optional) {
-                  return g -> g.writeString(optional ? "optional-logs" : "logs");
+                  return g -> g.writeString(optional ? STR_LOGS_OPTIONAL : STR_LOGS);
                 }
 
                 @Override
                 public Printer qualityControl(boolean optional) {
                   return g ->
-                      g.writeString(optional ? "optional-quality-control" : "quality-control");
+                      g.writeString(optional ? STR_QUALITY_CONTROL_OPTIONAL : STR_QUALITY_CONTROL);
                 }
 
                 @Override
                 public Printer unknown() {
-                  return g -> g.writeString("unknown");
+                  return g -> g.writeString(STR_UNKNOWN);
                 }
 
                 @Override
                 public Printer warehouseRecords(boolean optional) {
                   return g ->
-                      g.writeString(optional ? "optional-warehouse-records" : "warehouse-records");
+                      g.writeString(
+                          optional ? STR_WAREHOUSE_RECORDS_OPTIONAL : STR_WAREHOUSE_RECORDS);
                 }
               })
           .print(jsonGenerator);


### PR DESCRIPTION
There was a bug in OutputType.java resulting from the line:
`g.writeString(optional ? "optioal-quality-control" : "quality-control");`
when all other instances were 'optional-quality-control'.
Prevent bugs like that from happening again by controlling vocabulary instead of using repeated string literals.