### PR TITLE
Update database schema permissions on create

### DIFF
--- a/admin-guide.md
+++ b/admin-guide.md
@@ -56,6 +56,9 @@ Create a new PostgreSQL database and role for Víðarr.
 
     CREATE ROLE vidarr LOGIN PASSWORD 'mash keyboard here';
     CREATE DATABASE vidarr OWNER vidarr;
+    \c vidarr;
+    ALTER SCHEMA public OWNER TO vidarr;
+    GRANT ALL ON SCHEMA public TO vidarr;
 
 Now prepare the JSON configuration file `/srv/vidarr/config` as follows:
 


### PR DESCRIPTION
Once this PR is merged, I'm going to make these updates on our Vidarr deploys as well. 
The schemas on our deployed instances are owned by `postgres`, so `vidarr` can't drop the schemas for something like a restore.