### PR TITLE
Upgrade git code formatter plugin to work with Java 16

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
       <plugin>
         <groupId>com.cosium.code</groupId>
         <artifactId>git-code-format-maven-plugin</artifactId>
-        <version>3.0</version>
+        <version>3.1</version>
         <executions>
           <execution>
             <id>install-formatter-hook</id>


### PR DESCRIPTION
It still fails with Java 17 LTS, but does work with Java 16