### PR TITLE
GP-2851 fix external IDs comparison for MANUAL external keys

### DIFF
--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseProcessor.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseProcessor.java
@@ -274,7 +274,7 @@ public abstract class BaseProcessor<
                     new HashSet<>(activeWorkflow.requestedExternalIds());
                 // In the case of EXTERNAL ids, pass to ExtractInputExternalIds which knows how to
                 // make sense of whatever non-vidarr id we pass it
-                final var discoveredExternalIds =
+                final Set<ExternalId> discoveredExternalIds =
                     definition
                         .parameters()
                         .flatMap(
@@ -288,7 +288,10 @@ public abstract class BaseProcessor<
                                                 activeWorkflow.arguments().get(parameter.name()),
                                                 BaseProcessor.this))
                                     : Stream.empty())
-                        .map(ei -> new ExternalId(ei.getProvider(), ei.getId()))
+                        .map(
+                            ei ->
+                                new ExternalId(
+                                    ((ExternalId) ei).getProvider(), ((ExternalId) ei).getId()))
                         .collect(Collectors.toSet());
                 if (activeWorkflow
                         .extraInputIdsHandled() // Set to true when in Remaining or All case


### PR DESCRIPTION
From Mike's investigations in [GP-2851](https://jira.oicr.on.ca/browse/GP-2851?focusedCommentId=184522&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-184522), workflows that had MANUAL handling of external keys were failing because the code was trying to compare the subclass to the superclass. For this comparison the subclass `versions` property is irrelevant, so everything gets compared as type `ExternalId`. 

At this point in the code there isn't really access to something that writes to the active_operation table with a reason for the failure, so I've added an IllegalArgumentException like exists earlier in the method on line 268.