### PR TITLE
Update getWorkflowVersion output so that it can be posted to addWorkflowVersion

### DIFF
--- a/vidarr-server/src/main/resources/ca/on/oicr/gsi/vidarr/server/api-docs/vidarr.json
+++ b/vidarr-server/src/main/resources/ca/on/oicr/gsi/vidarr/server/api-docs/vidarr.json
@@ -33,11 +33,11 @@
             "type": "object",
             "properties": {
               "type": {
-                "description": "literal string 'type' of the kind of filter to be applied",
+                "description": "flavour of filter to be applied",
                 "type": "string"
               },
-              "name": {
-                "description": "name of the kind of filter to be applied",
+              "id/name/time/provider(s)": {
+                "description": "name/id/time/provider to filter on",
                 "type": "string"
               }
             }
@@ -1656,6 +1656,12 @@
           "description":  "Version of workflow",
           "required": true,
           "type": "string"
+        }, {
+          "name": "includeDefinitions",
+          "in": "query",
+          "description": "Include the workflow version definition files in the response? (true/false)",
+          "required": false,
+          "type": "boolean"
         }],
         "responses": {
           "200": {
@@ -1686,6 +1692,18 @@
                   "language": {
                     "description": "Workflow language",
                     "type": "string"
+                  },
+                  "outputs": {
+                    "description": "Workflow output types",
+                    "type": "object"
+                  },
+                  "workflow": {
+                    "description": "Text of the file that is run for this workflow version (only included if requested in the query)",
+                    "type": "string"
+                  },
+                  "accessoryFiles": {
+                    "description": "Map of the name of the subworkflow definition file and the contents of the subworkflow definition file (only included if requested in the query)",
+                    "type": "object"
                   }
                 }
               }
@@ -1756,7 +1774,7 @@
           "description": "The configuration parameters for a workflow version."
         },
         "responses": {
-          "200": {
+          "201": {
             "description": "The workflow version has been created."
           },
           "404": {

--- a/vidarr-server/src/test/resources/db/migration/V8888__integration_test_data.sql
+++ b/vidarr-server/src/test/resources/db/migration/V8888__integration_test_data.sql
@@ -19,7 +19,7 @@ INSERT INTO workflow (is_active, labels, max_in_flight, modified, name) VALUES
   INSERT INTO workflow_definition (hash_id, modified, workflow_file, workflow_language) VALUES
     ('cc77e42b11c4b4f4078138dc1b0a7c3695cd1d3ba6d39df5f7ef1e787ff0d92c',('2021-05-14 09:53:52-04'::timestamptz), 14010515, 'NIASSA'),
     ('fda21dd38f908cb11d7596d587c5c478c3e7627d78312a66c9657869a2ee95cf',('2021-05-14 09:53:52-04'::timestamptz), 14244254, 'NIASSA'),
-    ('f217aea7b3d62b86611b094252ff19aed3db6b29110f11c77368fe8595ae5d7a',('2021-05-14 09:53:52-04'::timestamptz), 538766, 'WDL_1_0'),
+    ('f217aea7b3d62b86611b094252ff19aed3db6b29110f11c77368fe8595ae5d7a',('2021-05-14 09:53:52-04'::timestamptz), 'version 1.1.0.538766\n\nworkflow bcl2fastq{}', 'WDL_1_0'),
     ('6f229aace247e07be3c667175891bc8f3bcec6ca66138d885cf09c2547721298',('2021-05-14 09:53:52-04'::timestamptz), 14696389, 'NIASSA'),
     ('322142e016e988712de8c373dd1ede27b243aec64b61cd4aa5aa5137e3754b54',('2021-05-14 09:53:52-04'::timestamptz), 11034, 'NIASSA'),
     ('9e39c488f09ead0403b8fe3a1d31942ecb6a5d32e379d96eab5b3f5ef0e2bd6f',('2021-05-14 09:53:52-04'::timestamptz), 996126, 'NIASSA'),
@@ -31,7 +31,7 @@ INSERT INTO workflow (is_active, labels, max_in_flight, modified, name) VALUES
     ('5f5e1bf5e856a1c923be41e1a272a51af19168e0597cd78c433a268849b2f892',('2021-05-14 09:53:52-04'::timestamptz), 17835339, 'NIASSA'),
     ('706ca65c70cce56c9df57674e805cebeea31867e8194dc29b78fa791563b0184',('2021-05-14 09:53:52-04'::timestamptz), 12901362, 'NIASSA'),
     ('926603f4b849f9b8e772a51af19168e0597cf1e8196cb88528067dca371d6b30',('2021-05-14 09:53:52-04'::timestamptz), 29438457, 'NIASSA'),
-    ('fa270cfa270cfa270cfa270cfa270cfa270cfa270cfa270cfa270cfa270cfa270c',('2021-07-25 10:04:34-04'::timestamptz), 327862, 'WDL_1_0')
+    ('fa270cfa270cfa270cfa270cfa270cfa270cfa270cfa270cfa270cfa270cfa270c',('2021-07-25 10:04:34-04'::timestamptz), 'version 1.0.0\n\nworkflow fastqc{}', 'WDL_1_0')
     ON CONFLICT DO NOTHING;
 
 INSERT INTO workflow_version (hash_id, metadata, modified, name, parameters, version, workflow_definition) VALUES


### PR DESCRIPTION
GP-3125 

This gives an easy way of copying specific workflow versions between Vidarr instances that doesn't rely on database manipulation

This PR also makes extra sure that workflow version is immutable, and workflow is minimally mutable (and not in a way that will affect existing analysis).