### PR TITLE
Max-In-Flight bugfixes

### DIFF
--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/MaxInFlightConsumableResource.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/MaxInFlightConsumableResource.java
@@ -45,6 +45,7 @@ public final class MaxInFlightConsumableResource implements ConsumableResource {
   public ConsumableResourceResponse request(
       String workflowName, String workflowVersion, String vidarrId, Optional<JsonNode> input) {
     if (inFlight.size() <= maximum) {
+      inFlight.add(vidarrId);
       return ConsumableResourceResponse.AVAILABLE;
     } else {
       return ConsumableResourceResponse.UNAVAILABLE;

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/MaxInFlightConsumableResource.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/MaxInFlightConsumableResource.java
@@ -42,7 +42,7 @@ public final class MaxInFlightConsumableResource implements ConsumableResource {
   }
 
   @Override
-  public ConsumableResourceResponse request(
+  public synchronized ConsumableResourceResponse request(
       String workflowName, String workflowVersion, String vidarrId, Optional<JsonNode> input) {
     if (inFlight.size() <= maximum) {
       inFlight.add(vidarrId);

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/MaxInFlightConsumableResource.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/MaxInFlightConsumableResource.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
+// This is the global one. Per-Workflow is MaxInFlightByWorkflow
 public final class MaxInFlightConsumableResource implements ConsumableResource {
   public static ConsumableResourceProvider provider() {
     return () -> Stream.of(new Pair<>("max-in-flight", MaxInFlightConsumableResource.class));

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
@@ -587,7 +587,7 @@ public abstract class DatabaseBackedProcessor
                 launched = true;
                 startTransaction(
                     runTransaction ->
-                        DatabaseBackedProcessor.this.start(
+                        DatabaseBackedProcessor.this.start( // runs when new workflow run submitted
                             target, workflow.definition(), dbWorkflow, runTransaction));
               }
             }));
@@ -1105,7 +1105,9 @@ public abstract class DatabaseBackedProcessor
                                                               startTransaction(
                                                                   runTransaction ->
                                                                       DatabaseBackedProcessor.this
-                                                                          .start( // run on retry
+                                                                          .start( // runs when
+                                                                              // action
+                                                                              // VIDARR-REATTEMPT'd
                                                                               target,
                                                                               workflow.definition(),
                                                                               dbWorkflow,

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
@@ -1091,8 +1091,7 @@ public abstract class DatabaseBackedProcessor
                                                           version,
                                                           candidateId,
                                                           consumableResources,
-                                                          new Runnable() { // return a
-                                                                           // ConsumableResourceChecker instead
+                                                          new Runnable() {
                                                             private boolean launched;
 
                                                             @Override

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/MaxInFlightByWorkflow.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/MaxInFlightByWorkflow.java
@@ -62,7 +62,7 @@ final class MaxInFlightByWorkflow implements ConsumableResource {
   }
 
   @Override
-  public ConsumableResourceResponse request(
+  public synchronized ConsumableResourceResponse request(
       String workflowName, String workflowVersion, String vidarrId, Optional<JsonNode> input) {
     final var state = workflows.get(workflowName);
     if (state == null) {


### PR DESCRIPTION
- Adds workflow run id to inflight set on request() at line 48 to mirror line 36
- hander.launched and handler.resubmit take Runnables as a parameter. ConsumableResourceChecker implements Runnable and the intention was to pass one to both methods, however this was overlooked on resubmit's call
- inline comments to clarify the distinct codepaths for new vs reattempted workflow runs
- prevent a very rare but largely harmless race condition that might look like a bug and waste dev time