### PR TITLE
AddWorkflowVersion for an existing workflow + version should succeed if the request is identical to the existing workflow verison, and fail otherwise

### DIFF
--- a/vidarr-server/src/main/resources/ca/on/oicr/gsi/vidarr/server/api-docs/vidarr.json
+++ b/vidarr-server/src/main/resources/ca/on/oicr/gsi/vidarr/server/api-docs/vidarr.json
@@ -1786,11 +1786,17 @@
           "description": "The configuration parameters for a workflow version."
         },
         "responses": {
+          "200": {
+            "description": "The workflow version already exists."
+          },
           "201": {
             "description": "The workflow version has been created."
           },
           "404": {
             "description": "No workflow with the given name was found."
+          },
+          "409": {
+            "description": "The submitted workflow version has the same name and version as an existing workflow version, but the submitted workflow script/accessory workflow scripts/outputs/parameters do not match the existing workflow version."
           }
         },
         "summary": "Add workflow version",

--- a/vidarr-server/src/test/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessorTest.java
+++ b/vidarr-server/src/test/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessorTest.java
@@ -38,7 +38,7 @@ public class DatabaseBackedProcessorTest {
 
   @ClassRule
   public static JdbcDatabaseContainer pg =
-      new PostgreSQLContainer("postgres:12-alpine")
+      new PostgreSQLContainer("postgres:13-alpine")
           .withDatabaseName(dbName)
           .withUsername(dbUser)
           .withPassword(dbPass);

--- a/vidarr-server/src/test/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedTestConfiguration.java
+++ b/vidarr-server/src/test/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedTestConfiguration.java
@@ -1,0 +1,50 @@
+package ca.on.oicr.gsi.vidarr.server;
+
+import ca.on.oicr.gsi.vidarr.core.RawInputProvisioner;
+import ca.on.oicr.gsi.vidarr.server.dto.ServerConfiguration;
+import java.util.Collections;
+import java.util.HashMap;
+import org.junit.rules.TemporaryFolder;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+public class DatabaseBackedTestConfiguration {
+
+  private static final String vidarrTest = "vidarr-test";
+  private static final String dbName = "vidarr-test";
+  private static final String dbUser = "vidarr-test";
+  private static final String dbPass = "vidarr-test";
+  private static final TemporaryFolder unloadDirectory = new TemporaryFolder();
+
+  public static JdbcDatabaseContainer getTestDatabaseContainer() {
+    return new PostgreSQLContainer("postgres:13-alpine")
+        .withDatabaseName(dbName)
+        .withUsername(dbUser)
+        .withPassword(dbPass);
+  }
+
+  protected static ServerConfiguration getTestServerConfig(
+      JdbcDatabaseContainer pg, TemporaryFolder unloadDir, int port) {
+    ServerConfiguration config = new ServerConfiguration();
+    config.setName(pg.getContainerName());
+    config.setDbHost(pg.getHost());
+    config.setDbName(pg.getDatabaseName());
+    config.setDbPass(pg.getPassword());
+    config.setDbUser(pg.getUsername());
+    config.setDbPort(pg.getFirstMappedPort());
+    config.setPort(port);
+    config.setUrl("http://localhost:" + port);
+    config.setOtherServers(new HashMap<>());
+    config.setInputProvisioners(Collections.singletonMap("raw", new RawInputProvisioner()));
+    config.setWorkflowEngines(new HashMap<>());
+    config.setOutputProvisioners(new HashMap<>());
+    config.setRuntimeProvisioners(new HashMap<>());
+    config.setTargets(new HashMap<>());
+    config.setUnloadDirectory(unloadDir.getRoot().getAbsolutePath());
+    return config;
+  }
+
+  protected static TemporaryFolder getUnloadDirectory() {
+    return unloadDirectory;
+  }
+}

--- a/vidarr-server/src/test/java/ca/on/oicr/gsi/vidarr/server/MainIntegrationTest.java
+++ b/vidarr-server/src/test/java/ca/on/oicr/gsi/vidarr/server/MainIntegrationTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
 import ca.on.oicr.gsi.vidarr.core.Phase;
-import ca.on.oicr.gsi.vidarr.core.RawInputProvisioner;
 import ca.on.oicr.gsi.vidarr.server.dto.ServerConfiguration;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -29,7 +28,6 @@ import java.text.ParseException;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -45,49 +43,27 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.postgresql.ds.PGSimpleDataSource;
-import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.JdbcDatabaseContainer;
-import org.testcontainers.containers.PostgreSQLContainer;
 
 public class MainIntegrationTest {
   @ClassRule
   public static JdbcDatabaseContainer pg =
-      new PostgreSQLContainer("postgres:13-alpine")
-          .withDatabaseName("vidarr-test")
-          .withUsername("vidarr-test")
-          .withPassword("vidarr-test");
+      DatabaseBackedTestConfiguration.getTestDatabaseContainer();
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private static ServerConfiguration config;
   private static Main main;
   private static final HttpClient CLIENT =
       HttpClient.newBuilder().followRedirects(Redirect.NORMAL).build();
-  @ClassRule public static final TemporaryFolder unloadDirectory = new TemporaryFolder();
 
-  private static ServerConfiguration getTestServerConfig(GenericContainer pg) {
-    ServerConfiguration config = new ServerConfiguration();
-    config.setName("vidarr-test");
-    config.setDbHost(pg.getHost());
-    config.setDbName("vidarr-test");
-    config.setDbPass("vidarr-test");
-    config.setDbUser("vidarr-test");
-    config.setDbPort(pg.getFirstMappedPort());
-    config.setPort(8999);
-    config.setUrl("http://localhost:" + config.getPort());
-    config.setOtherServers(new HashMap<>());
-    config.setInputProvisioners(Collections.singletonMap("raw", new RawInputProvisioner()));
-    config.setWorkflowEngines(new HashMap<>());
-    config.setOutputProvisioners(new HashMap<>());
-    config.setRuntimeProvisioners(new HashMap<>());
-    config.setTargets(new HashMap<>());
-    config.setUnloadDirectory(unloadDirectory.getRoot().getAbsolutePath());
-    return config;
-  }
+  @ClassRule
+  public static final TemporaryFolder unloadDirectory =
+      DatabaseBackedTestConfiguration.getUnloadDirectory();
 
   @BeforeClass
   public static void setup() throws SQLException {
     TimeZone.setDefault(TimeZone.getTimeZone("America/Toronto"));
-    config = getTestServerConfig(pg);
+    config = DatabaseBackedTestConfiguration.getTestServerConfig(pg, unloadDirectory, 8999);
     main = new Main(config);
     main.startServer(main);
     RestAssured.baseURI = config.getUrl();

--- a/vidarr-server/src/test/java/ca/on/oicr/gsi/vidarr/server/MainIntegrationTest.java
+++ b/vidarr-server/src/test/java/ca/on/oicr/gsi/vidarr/server/MainIntegrationTest.java
@@ -610,6 +610,22 @@ public class MainIntegrationTest {
         .then()
         .assertThat()
         .statusCode(200);
+
+    var existingVersionWithoutDefinitions =
+        get("/api/workflow/{workflow}/{version}", wfName, wfVersion)
+            .then()
+            .extract()
+            .body()
+            .as(new TypeRef<Map<String, Object>>() {});
+
+    given()
+        .contentType(ContentType.JSON)
+        .body(MAPPER.writeValueAsString(existingVersionWithoutDefinitions))
+        .when()
+        .post("/api/workflow/{workflow}/{version}", wfName, wfVersion)
+        .then()
+        .assertThat()
+        .statusCode(400);
   }
 
   @Test

--- a/vidarr-server/src/test/java/ca/on/oicr/gsi/vidarr/server/VeryBadDataIntegrationTest.java
+++ b/vidarr-server/src/test/java/ca/on/oicr/gsi/vidarr/server/VeryBadDataIntegrationTest.java
@@ -35,7 +35,7 @@ import org.testcontainers.containers.PostgreSQLContainer;
 public class VeryBadDataIntegrationTest {
   @ClassRule
   public static JdbcDatabaseContainer pg =
-      new PostgreSQLContainer("postgres:12-alpine")
+      new PostgreSQLContainer("postgres:13-alpine")
           .withDatabaseName("vidarr-test")
           .withUsername("vidarr-test")
           .withPassword("vidarr-test");


### PR DESCRIPTION
GP-3138

Right now it returns 409 CONFLICT if any matching workflow version is found. This return code should be reserved for if the matching workflow version is different from the submitted workflow version.

This will alert workflow developers if they are attempting to change a workflow version.