### PR TITLE
Revert "[GP-3129] Create index on niassa-file-accession"

### DIFF
--- a/vidarr-server/src/main/resources/db/migration/V0013__niassa_accession_index.sql
+++ b/vidarr-server/src/main/resources/db/migration/V0013__niassa_accession_index.sql
@@ -1,1 +1,0 @@
-CREATE INDEX niassa_file_swid_index ON analysis ((labels ->> 'niassa-file-accession'));


### PR DESCRIPTION
Reverts oicr-gsi/vidarr#146 because we're not searching on this field in the niassa skip cron any more