### PR TITLE
Fix issue where Vidarr is resolving incorrect file paths

### DIFF
--- a/changes/fix_file_path_resolution.md
+++ b/changes/fix_file_path_resolution.md
@@ -1,0 +1,1 @@
+Fix issue where unloading a file and loading in a new file with the same hash_id would cause the old file path to be used.

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
@@ -121,7 +121,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Semaphore;
@@ -479,7 +478,6 @@ public final class Main implements ServerConfig {
   private final Map<String, InputProvisioner> inputProvisioners;
   private final Semaphore loadCounter = new Semaphore(3);
   private final MaxInFlightByWorkflow maxInFlightPerWorkflow = new MaxInFlightByWorkflow();
-  private final Map<String, Optional<FileMetadata>> metadataCache = new ConcurrentHashMap<>();
   private final Map<String, String> otherServers;
   private final Map<String, OutputProvisioner> outputProvisioners;
   private final int port;
@@ -732,7 +730,7 @@ public final class Main implements ServerConfig {
 
           @Override
           public Optional<FileMetadata> pathForId(String id) {
-            return metadataCache.computeIfAbsent(id, this::fetchPathForId);
+            return this.fetchPathForId(id);
           }
 
           @Override


### PR DESCRIPTION
This metadata cache is only used when transitioning a workflow run to active, and we don't use Vidarr federation yet so it doesn't save that much time. If removing the cache proves to be an issue, we can reimplement it and properly remove items from the cache when they are unloaded.

Jira ticket: GP-3269 

- [x] Includes a change file
