### PR TITLE
Upgrade interlinked dependencies

### DIFF
--- a/changes/change_upgrade_jooq_rest-assured_jackson.md
+++ b/changes/change_upgrade_jooq_rest-assured_jackson.md
@@ -1,0 +1,3 @@
+Bump jooq from 3.14.0 to 3.16.5
+Bump rest-assured packages from 4.4.0 to 5.0.0
+Bump jackson dependencies

--- a/pom.xml
+++ b/pom.xml
@@ -145,13 +145,13 @@
       <dependency>
         <groupId>io.rest-assured</groupId>
         <artifactId>json-path</artifactId>
-        <version>4.4.0</version>
+        <version>5.0.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>io.rest-assured</groupId>
         <artifactId>xml-path</artifactId>
-        <version>4.4.0</version>
+        <version>5.0.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
       <dependency>
         <groupId>org.jooq</groupId>
         <artifactId>jooq</artifactId>
-        <version>3.14.0</version>
+        <version>3.16.5</version>
       </dependency>
       <dependency>
         <groupId>org.jooq</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,17 +49,17 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>[2.11.0, )</version>
+        <version>[2.13.2, )</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>[2.11.0, )</version>
+        <version>[2.13.2.2, )</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jsr310</artifactId>
-        <version>[2.11.0, )</version>
+        <version>[2.13.2, )</version>
       </dependency>
       <dependency>
         <groupId>io.undertow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
       <dependency>
         <groupId>io.rest-assured</groupId>
         <artifactId>rest-assured</artifactId>
-        <version>4.4.0</version>
+        <version>5.0.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
The jOOQ PR #153 needed the changes from the rest-assured update #156 , which itself needed the rest of the packages from rest-assured to be upgraded. The Jackson changes are independent, but related to another vulnerability.