### PR TITLE
Add cram to EXTENSION_TO_META_TYPE map

### DIFF
--- a/changes/change_extension_to_metadata_mapping.md
+++ b/changes/change_extension_to_metadata_mapping.md
@@ -1,0 +1,1 @@
+Changed the EXTENSION_TO_METADATA mapping in CromwellOutputProvisioner to include .crai and .cram extensions.

--- a/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/CromwellOutputProvisioner.java
+++ b/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/CromwellOutputProvisioner.java
@@ -55,11 +55,6 @@ public class CromwellOutputProvisioner
           new Pair<>(".cram", "application/cram"),
           new Pair<>(".crai", "application/cram-index"),
           new Pair<>("", "application/octet-stream"));
-This branch has not been deployed
-No deployments
-Changes requested
-1 review requesting changes and 1 approving review
-
 
   public static OutputProvisionerProvider provider() {
     return () -> Stream.of(new Pair<>("cromwell", CromwellOutputProvisioner.class));

--- a/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/CromwellOutputProvisioner.java
+++ b/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/CromwellOutputProvisioner.java
@@ -52,9 +52,14 @@ public class CromwellOutputProvisioner
           new Pair<>(".seg", "application/seg"),
           new Pair<>(".Rdata", "application/rdata"),
           new Pair<>(".RData", "application/rdata"),
-          new Pair<>("", "application/octet-stream"),
           new Pair<>(".cram", "application/cram"),
-          new Pair<>(".crai", "application/cram-index"));
+          new Pair<>(".crai", "application/cram-index"),
+          new Pair<>("", "application/octet-stream"));
+This branch has not been deployed
+No deployments
+Changes requested
+1 review requesting changes and 1 approving review
+
 
   public static OutputProvisionerProvider provider() {
     return () -> Stream.of(new Pair<>("cromwell", CromwellOutputProvisioner.class));

--- a/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/CromwellOutputProvisioner.java
+++ b/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/CromwellOutputProvisioner.java
@@ -52,7 +52,9 @@ public class CromwellOutputProvisioner
           new Pair<>(".seg", "application/seg"),
           new Pair<>(".Rdata", "application/rdata"),
           new Pair<>(".RData", "application/rdata"),
-          new Pair<>("", "application/octet-stream"));
+          new Pair<>("", "application/octet-stream"),
+          new Pair<>(".cram", "application/cram"),
+          new Pair<>(".crai", "application/cram-index"));
 
   public static OutputProvisionerProvider provider() {
     return () -> Stream.of(new Pair<>("cromwell", CromwellOutputProvisioner.class));


### PR DESCRIPTION
Jira ticket: GP-3227

Changes to CromwellOutputProvisioner to add .cram and .crai EXTENSION_TO_META_TYPE mapping.