### PR TITLE
GP-2847_Return-latest-version-when-versionTypes-not-specified

### DIFF
--- a/changes/add_test_cases_for_provenance_api_versions_returning_latest.md
+++ b/changes/add_test_cases_for_provenance_api_versions_returning_latest.md
@@ -1,0 +1,1 @@
+Added test cases in MainIntegrationTest.java for cases when versionTypes not specified or null and versionPolicy is LATEST to return latest version.

--- a/changes/fix_returning_null_versions.md
+++ b/changes/fix_returning_null_versions.md
@@ -1,0 +1,1 @@
+Fix condition in createVersionQuery to return latest version when versionTypes not specified

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
@@ -307,7 +307,7 @@ public final class Main implements ServerConfig {
   private static Field<?> createQueryOnVersion(
       Function<ExternalIdVersion, Field<?>> fieldConstructor, Set<String> allowedTypes) {
     var condition = EXTERNAL_ID.ID.eq(EXTERNAL_ID_VERSION.EXTERNAL_ID_ID);
-    if (allowedTypes != null) {
+    if (allowedTypes != null && allowedTypes.size() != 0) {
       condition = condition.and(EXTERNAL_ID_VERSION.KEY.in(allowedTypes));
     }
     final var externalIdVersionAlias = EXTERNAL_ID_VERSION.as("externalIdVersionInner");

--- a/vidarr-server/src/test/java/ca/on/oicr/gsi/vidarr/server/MainIntegrationTest.java
+++ b/vidarr-server/src/test/java/ca/on/oicr/gsi/vidarr/server/MainIntegrationTest.java
@@ -936,11 +936,40 @@ public class MainIntegrationTest {
   }
 
   @Test
-  public void
-      whenGetProvenanceRecordsLatestVersions_VersionTypesNotSpecified_thenReturnLatestVersion() {
+  public void whenGetProvenanceRecordsLatestVersion_VersionTypesNull_thenReturnLatestVersion() {
     var requestBody =
         buildProvenanceRequestBody("LATEST", Instant.ofEpochMilli(0), Instant.ofEpochMilli(0));
-    requestBody.put("versionTypes", "");
+    requestBody.putNull("versionTypes"); // versionTypes is null
+    var results =
+        given()
+            .contentType(ContentType.JSON)
+            .body(requestBody)
+            .when()
+            .post("/api/provenance")
+            .then()
+            .assertThat()
+            .statusCode(200)
+            .and()
+            .extract()
+            .body()
+            .as(ProvenanceResponse.class)
+            .getResults();
+    var externalKeysList =
+        results.stream().map(r -> r.get("externalKeys")).collect(Collectors.toSet());
+    externalKeysList.forEach(
+        ekl ->
+            ekl.forEach(
+                ek -> {
+                  assertTrue(ek.get("versions") != null || !ek.get("versions").isNull());
+                }));
+  }
+
+  @Test
+  public void
+      whenGetProvenanceRecordsLatestVersion_VersionTypesNotSpecified_thenReturnLatestVersion() {
+    var requestBody =
+        buildProvenanceRequestBody("LATEST", Instant.ofEpochMilli(0), Instant.ofEpochMilli(0));
+    requestBody.remove("versionTypes"); // Version types is not specified
     var results =
         given()
             .contentType(ContentType.JSON)


### PR DESCRIPTION
Jira ticket: GP-2847 Vidarr provenance api returns no versions when empty versionTypes and LATEST versionPolicy is specified

- [x] Includes a change file
