### PR TITLE
Reformat comments and add contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# How to contribute
+
+We're glad you're interested in contributing to the development of Víðarr and are happy to collaborate.
+Please review this document to ensure that your work fits well into the Víðarr code base.
+
+## Tickets
+
+Create a ticket for your issue if one does not exist. As development of Víðarr is mainly done at OICR
+currently, the ticket is usually on the internal OICR JIRA, but a GitHub Issue is also acceptable.
+This ensures that we have a place to discuss the changes before the work is done. A ticket is not
+necessary if the change is trivial, such as correcting a typo.
+
+## Branches
+
+Create a feature branch. The branch should be based on the `master` branch unless you have reason
+to do otherwise. The branch name should begin with the ticket/issue number, and be followed by a brief hint
+of what it is about. e.g. "#1234_fixLibraryPage"
+
+## Code Formatting
+
+Please format your code using `google-java-format`. This plugin can be installed in IntelliJ IDEA. Changes that are incorrectly formatted will cause the build to fail.
+
+## Testing
+
+We have several types of automated testing:
+
+* Unit tests and integration tests
+  * Run with `mvn clean test`
+* REST API Integration tests
+  * Run with `mvn clean test -Dtest=MainIntegrationTest`
+
+You can run individual test classes or methods by adding `-Dtest=ClassName` or `Dtest=ClassName#methodName`
+
+Please make sure to add or update the relevant tests for your changes.
+
+## Commits
+
+* Make sure your commit messages begin with the issue number. e.g. "#1234: Fix issue where unloading a file and loading in a new file with the same hash_id would cause the old file path to be used."
+* Include change messages as described [here](changes/README.md) if your change will be user-facing
+
+## Pull Requests
+
+Changes should never be merged directly into `master`. Pull requests should be made into
+the `master` branch for testing and review.
+
+The pull request description will automatically be filled in with the 
+[pull request template](.github/pull_request_template.md). Please link to the issue for this 
+pull request and complete the checklist.
+
+## Merging
+
+Once all of the tests are passing, and your pull request has received two approvals, you are ready to
+merge. To keep a clean commit history please
+
+1. Squash your changes into one commit unless they are clearly separate changes.
+2. Rebase on the `develop` branch so that your change appears after the changes that were previously
+merged in the history.
+
+You can usually use the 'Squash and merge' feature on GitHub to do this. Use the 'Rebase and merge'
+feature if you would like to keep the commits separate. If you have a more complex situation, such as
+wanting to squash some commits but not others, you should use `git rebase` and then re-run tests
+before merging. If you do not have the necessary permissions to merge into `develop`, please request
+for someone else to do the merge.
+
+Please delete your feature branch after it is merged.
+
+### Thank you for your contributions!

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/OutputProvisioner.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/OutputProvisioner.java
@@ -20,14 +20,16 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 import javax.xml.stream.XMLStreamException;
 
-/** A mechanism to collect output data from a workflow and push it into an appropriate data store
+/**
+ * A mechanism to collect output data from a workflow and push it into an appropriate data store
  *
- * OutputProvisioners run once per output file for a workflow run. This is different from the RuntimeProvisioner,
- * which executes once per workflow run. Both are called at the end of the RUNNING phase.
+ * <p>OutputProvisioners run once per output file for a workflow run. This is different from the
+ * RuntimeProvisioner, which executes once per workflow run. Both are called at the end of the
+ * RUNNING phase.
  *
- * OutputProvisioner uses jackson-databind to map information from the server's '.vidarrconfig' file to
- * member non-static fields. The @JsonIgnore annotation prevents this.
- * */
+ * <p>OutputProvisioner uses jackson-databind to map information from the server's '.vidarrconfig'
+ * file to member non-static fields. The @JsonIgnore annotation prevents this.
+ */
 @JsonTypeIdResolver(OutputProvisioner.OutputProvisionerIdResolver.class)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, include = As.PROPERTY, property = "type")
 public interface OutputProvisioner {
@@ -77,7 +79,7 @@ public interface OutputProvisioner {
     void file(String storagePath, String md5, long size, String metatype);
 
     /**
-     * The output is a reference to another system
+     * The output is a reference to another system *
      *
      * @param url the URL that describes how to find the output in the remote system
      */

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/RuntimeProvisioner.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/RuntimeProvisioner.java
@@ -22,18 +22,21 @@ import javax.xml.stream.XMLStreamException;
  * A mechanism to collect metrics and log data from a workflow and push it into an appropriate data
  * store
  *
- * <p>It does not operate on individual output from a workflow run, but on the workflow run
- * itself, provided by an identifier that connects it to the workflow engine that ran it. This distinguishes the
- * RuntimeProvisioner from the OutputProvisioner - RuntimeProvisioners run once per workflow run; OutputProvisioners
- * run once per output file (potentially many times per workflow run). Both are called at the end of the RUNNING phase.
+ * <p>It does not operate on individual output from a workflow run, but on the workflow run itself,
+ * provided by an identifier that connects it to the workflow engine that ran it. This distinguishes
+ * the RuntimeProvisioner from the OutputProvisioner - RuntimeProvisioners run once per workflow
+ * run; OutputProvisioners run once per output file (potentially many times per workflow run). Both
+ * are called at the end of the RUNNING phase.
  *
- * RuntimeProvisioner uses jackson-databind to map information from the server's '.vidarrconfig' file to
- * member non-static fields. The @JsonIgnore annotation prevents this.
+ * <p>RuntimeProvisioner uses jackson-databind to map information from the server's '.vidarrconfig'
+ * file to member non-static fields. The @JsonIgnore annotation prevents this.
  */
 @JsonTypeIdResolver(RuntimeProvisioner.RuntimeProvisionerIdResolver.class)
 @JsonTypeInfo(use = JsonTypeInfo.Id.CUSTOM, include = As.PROPERTY, property = "type")
 public interface RuntimeProvisioner {
+
   final class RuntimeProvisionerIdResolver extends TypeIdResolverBase {
+
     private final Map<String, Class<? extends RuntimeProvisioner>> knownIds =
         ServiceLoader.load(RuntimeProvisionerProvider.class).stream()
             .map(Provider::get)
@@ -65,10 +68,13 @@ public interface RuntimeProvisioner {
       return clazz == null ? null : context.constructType(clazz);
     }
   }
+
   /** Write configuration information to the Vidarr status page. */
   void configuration(SectionRenderer sectionRenderer) throws XMLStreamException;
 
-  /** The unique name of this plugin. Required for journaling state to database and crash recovery. */
+  /**
+   * The unique name of this plugin. Required for journaling state to database and crash recovery.
+   */
   String name();
 
   /**
@@ -76,9 +82,8 @@ public interface RuntimeProvisioner {
    *
    * @param workflowRunUrl the URL provided by the {@link WorkflowEngine.Result#workflowRunUrl()}
    * @param monitor WorkMonitor for writing the output of the checking process and scheduling
-   *                asynchronous tasks.
-   *                OutputProvisioner.Result is the expected output type.
-   *                JsonNode is the format of the state records.
+   *     asynchronous tasks. OutputProvisioner.Result is the expected output type. JsonNode is the
+   *     format of the state records.
    * @return JsonNode used by WrappedMonitor in BaseProcessor.Phase3Run to serialize to the database
    */
   JsonNode provision(
@@ -87,7 +92,8 @@ public interface RuntimeProvisioner {
   /**
    * Restart a provisioning process from state saved in the database
    *
-   * Rebuild state from `state` object then schedule appropriate next step with `monitor.scheduleTask()`
+   * <p>Rebuild state from `state` object then schedule appropriate next step with
+   * `monitor.scheduleTask()`
    *
    * @param state the frozen database state
    * @param monitor the monitor structure for writing the output of the provisioning process
@@ -97,8 +103,8 @@ public interface RuntimeProvisioner {
   /**
    * Called to initialise this runtime provisioner.
    *
-   * Actual reading of configuration files does not need to be done, due to jackson-databind populating
-   * member fields automatically.
+   * <p>Actual reading of configuration files does not need to be done, due to jackson-databind
+   * populating member fields automatically.
    *
    * <p>If the configuration is invalid, this should throw a runtime exception.
    */

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/WorkMonitor.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/WorkMonitor.java
@@ -11,12 +11,13 @@ import java.util.concurrent.TimeUnit;
  * scheduling or process behaviour on plugins. Plugins may manage their tasks however they please
  * and asynchronously report their status back to Vidarr using a monitor.
  *
- * complete() and permanentFailure() are not to be called directly, but rather inside the Runnable parameter of
- * a call to scheduleTask(). This is to prevent database corruption - Vidarr needs to wait for database
- * transactions to complete before doing any scheduled tasks, including marking tasks as completed or failed.
- * Calling these methods directly would risk trying to write during or after that transaction rolls back in an
- * error state.
- * See vidarr-core BaseProcessor.java's startNextPhase(), BaseProcessor's BaseOperationMonitor,
+ * <p>complete() and permanentFailure() are not to be called directly, but rather inside the
+ * Runnable parameter of a call to scheduleTask(). This is to prevent database corruption - Vidarr
+ * needs to wait for database transactions to complete before doing any scheduled tasks, including
+ * marking tasks as completed or failed. Calling these methods directly would risk trying to write
+ * during or after that transaction rolls back in an error state.
+ *
+ * <p>See vidarr-core BaseProcessor.java's startNextPhase(), BaseProcessor's BaseOperationMonitor,
  * and vidarr-server DatabaseWorkflow's phase()
  *
  * @param <T> the output type expected from the task
@@ -45,8 +46,8 @@ public interface WorkMonitor<T, S> {
   /**
    * The task is complete
    *
-   * Do not call directly from plugin. Call inside the Runnable parameter of {@link #scheduleTask(Runnable)}
-   * This is to prevent database corruption.
+   * <p>Do not call directly from plugin. Call inside the Runnable parameter of {@link
+   * #scheduleTask(Runnable)} This is to prevent database corruption.
    *
    * <p>This can only be called once and cannot be called if {@link #permanentFailure(String)} has
    * been called.
@@ -66,8 +67,8 @@ public interface WorkMonitor<T, S> {
   /**
    * Indicate that the task is unrecoverably broken
    *
-   * Do not call directly from plugin. Call inside the Runnable parameter of {@link #scheduleTask(Runnable)}
-   * This is to prevent database corruption.
+   * <p>Do not call directly from plugin. Call inside the Runnable parameter of {@link
+   * #scheduleTask(Runnable)} This is to prevent database corruption.
    *
    * <p>Once called, the workflow and related provisioning steps will be considered a failure.
    *


### PR DESCRIPTION
Jira ticket: GP-3357

Vidarr was failing to build because of incorrectly-formatted Javadocs. Please follow [these instructions](https://stackoverflow.com/a/42979701) to install and enable the `google-java-format` plugin for IntelliJ, as the vidarr-intellij-style.xml plugin is no longer compatible with later versions of the git code formatter plugin that Vidarr uses.

- [x] Includes a change file
- [x] Updates developer documentation

