### PR TITLE
Create index -> create index if not exists

### DIFF
--- a/vidarr-server/src/main/resources/db/migration/V0014__niassa_workflow_run_swid_index.sql
+++ b/vidarr-server/src/main/resources/db/migration/V0014__niassa_workflow_run_swid_index.sql
@@ -1,1 +1,1 @@
-CREATE INDEX niassa_workflow_run_swid_index ON workflow_run ((arguments ->> 'workflowRunSWID'));
+CREATE INDEX IF NOT EXISTS niassa_workflow_run_swid_index ON workflow_run ((arguments ->> 'workflowRunSWID'));


### PR DESCRIPTION
This change makes the code more flexible and could allow us to add the index to a deployed Vidarr before the release is performed (namely, to support migration timestamp updates). 

