### PR TITLE
Add a `retry` type to automatically re-attempt workflows

### DIFF
--- a/changes/add_retry
+++ b/changes/add_retry
@@ -1,0 +1,1 @@
+* Adds a new `retry` type that allows a workflows that fail to be retried with different arguments

--- a/vidarr-cli/src/main/java/ca/on/oicr/gsi/vidarr/cli/SingleShotWorkflow.java
+++ b/vidarr-cli/src/main/java/ca/on/oicr/gsi/vidarr/cli/SingleShotWorkflow.java
@@ -25,7 +25,8 @@ final class SingleShotWorkflow implements ActiveWorkflow<SingleShotOperation, Vo
   private final JsonNode metadata;
   private Phase phase = Phase.INITIALIZING;
   private final String prefix;
-  private ObjectNode realInput;
+  private List<ObjectNode> realInput;
+  private int realInputIndex = 0;
   private final OutputProvisioningHandler<Void> resultHandler;
 
   SingleShotWorkflow(
@@ -158,13 +159,18 @@ final class SingleShotWorkflow implements ActiveWorkflow<SingleShotOperation, Vo
   }
 
   @Override
-  public ObjectNode realInput() {
-    return realInput;
+  public void realInput(List<ObjectNode> realInput, Void transaction) {
+    this.realInput = realInput;
   }
 
   @Override
-  public void realInput(ObjectNode realInput, Void transaction) {
-    this.realInput = realInput;
+  public int realInputTryNext(Void transaction) {
+    return ++realInputIndex;
+  }
+
+  @Override
+  public List<ObjectNode> realInputs() {
+    return realInput;
   }
 
   @Override

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/ActiveWorkflow.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/ActiveWorkflow.java
@@ -94,16 +94,19 @@ public interface ActiveWorkflow<O extends ActiveOperation<TX>, TX>
    */
   void preflightFailed(TX transaction);
 
-  /** Get the parameters after provisioning in has modified them */
-  ObjectNode realInput();
-
   /**
    * Set the parameters after provisioning in has modified them
    *
    * @param realInput the modified parameters
    * @param transaction the transaction to update the information in
    */
-  void realInput(ObjectNode realInput, TX transaction);
+  void realInput(List<ObjectNode> realInput, TX transaction);
+
+  /** Increment the current real input index and return it */
+  int realInputTryNext(TX transaction);
+
+  /** Get all variations of the parameters after provisioning in has modified them */
+  List<ObjectNode> realInputs();
 
   /** Get the external IDs associated with the files in this workflow run */
   Set<ExternalId> requestedExternalIds();

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/ApplyRetry.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/ApplyRetry.java
@@ -1,0 +1,25 @@
+package ca.on.oicr.gsi.vidarr.core;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.List;
+import java.util.function.Consumer;
+
+final class ApplyRetry implements Consumer<ObjectNode> {
+  private final List<JsonPath> jsonPath;
+  private final JsonNode value;
+
+  public ApplyRetry(List<JsonPath> jsonPath, JsonNode value) {
+    this.jsonPath = jsonPath;
+    this.value = value;
+  }
+
+  @Override
+  public void accept(ObjectNode objectNode) {
+    JsonNode current = objectNode;
+    for (var i = 0; i < jsonPath.size() - 1; i++) {
+      current = jsonPath.get(i).get(current);
+    }
+    jsonPath.get(jsonPath.size() - 1).set(current, value);
+  }
+}

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/ExtractInputExternalIds.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/ExtractInputExternalIds.java
@@ -1,5 +1,6 @@
 package ca.on.oicr.gsi.vidarr.core;
 
+import ca.on.oicr.gsi.vidarr.BasicType;
 import ca.on.oicr.gsi.vidarr.InputProvisionFormat;
 import ca.on.oicr.gsi.vidarr.InputType;
 import ca.on.oicr.gsi.vidarr.api.ExternalId;
@@ -11,6 +12,7 @@ import java.util.stream.Stream;
 /** Fina all external IDs referenced by the input */
 public final class ExtractInputExternalIds
     extends BaseInputExtractor<
+        Stream<? extends ExternalId>,
         Stream<? extends ExternalId>,
         Stream<? extends ExternalId>,
         Stream<? extends ExternalId>,
@@ -47,6 +49,12 @@ public final class ExtractInputExternalIds
   protected Stream<? extends ExternalId> aggregateObject(
       Stream<Stream<? extends ExternalId>> fields) {
     return fields.flatMap(Function.identity());
+  }
+
+  @Override
+  protected Stream<? extends ExternalId> aggregateRetry(
+      Stream<Stream<? extends ExternalId>> alternatives) {
+    return alternatives.flatMap(Function.identity());
   }
 
   @Override
@@ -107,6 +115,11 @@ public final class ExtractInputExternalIds
 
   @Override
   public Stream<? extends ExternalId> json() {
+    return Stream.empty();
+  }
+
+  @Override
+  protected Stream<? extends ExternalId> retry(String id, BasicType type, JsonNode value) {
     return Stream.empty();
   }
 

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/ExtractInputVidarrIds.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/ExtractInputVidarrIds.java
@@ -1,5 +1,6 @@
 package ca.on.oicr.gsi.vidarr.core;
 
+import ca.on.oicr.gsi.vidarr.BasicType;
 import ca.on.oicr.gsi.vidarr.InputProvisionFormat;
 import ca.on.oicr.gsi.vidarr.InputType;
 import ca.on.oicr.gsi.vidarr.api.ExternalId;
@@ -11,7 +12,12 @@ import java.util.stream.Stream;
 /** Find all Vidarr IDs reference by the input to a workflow run */
 public final class ExtractInputVidarrIds
     extends BaseInputExtractor<
-        Stream<String>, Stream<String>, Stream<String>, Stream<String>, Stream<String>> {
+        Stream<String>,
+        Stream<String>,
+        Stream<String>,
+        Stream<String>,
+        Stream<String>,
+        Stream<String>> {
 
   private final ObjectMapper mapper;
 
@@ -38,6 +44,11 @@ public final class ExtractInputVidarrIds
   @Override
   protected Stream<String> aggregateObject(Stream<Stream<String>> fields) {
     return fields.flatMap(Function.identity());
+  }
+
+  @Override
+  protected Stream<String> aggregateRetry(Stream<Stream<String>> alternatives) {
+    return alternatives.flatMap(Function.identity());
   }
 
   @Override
@@ -91,6 +102,11 @@ public final class ExtractInputVidarrIds
 
   @Override
   public Stream<String> json() {
+    return Stream.empty();
+  }
+
+  @Override
+  protected Stream<String> retry(String id, BasicType type, JsonNode value) {
     return Stream.empty();
   }
 

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/ExtractRetryValues.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/ExtractRetryValues.java
@@ -1,0 +1,149 @@
+package ca.on.oicr.gsi.vidarr.core;
+
+import ca.on.oicr.gsi.vidarr.BasicType;
+import ca.on.oicr.gsi.vidarr.InputProvisionFormat;
+import ca.on.oicr.gsi.vidarr.InputType;
+import ca.on.oicr.gsi.vidarr.api.ExternalId;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/** Extract all the values associated with retry values in the input */
+public class ExtractRetryValues
+    extends BaseInputExtractor<
+        Stream<Integer>,
+        Stream<Integer>,
+        Stream<Integer>,
+        Stream<Integer>,
+        Stream<Integer>,
+        Stream<Integer>> {
+  private final ObjectMapper mapper;
+
+  public ExtractRetryValues(ObjectMapper mapper, JsonNode input) {
+    super(input);
+    this.mapper = mapper;
+  }
+
+  @Override
+  protected Stream<Integer> aggregateList(Stream<Stream<Integer>> elements) {
+    return elements.flatMap(Function.identity());
+  }
+
+  @Override
+  protected Stream<Integer> aggregateObject(Stream<Stream<Integer>> fields) {
+    return fields.flatMap(Function.identity());
+  }
+
+  @Override
+  protected Stream<Integer> aggregateRetry(Stream<Stream<Integer>> alternatives) {
+    return alternatives.flatMap(Function.identity());
+  }
+
+  @Override
+  protected Stream<Integer> aggregateTuple(Stream<Stream<Integer>> elements) {
+    return elements.flatMap(Function.identity());
+  }
+
+  @Override
+  public Stream<Integer> bool() {
+    return Stream.empty();
+  }
+
+  @Override
+  public Stream<Integer> date() {
+    return Stream.empty();
+  }
+
+  @Override
+  public Stream<Integer> floating() {
+    return Stream.empty();
+  }
+
+  @Override
+  public Stream<Integer> integer() {
+    return Stream.empty();
+  }
+
+  @Override
+  public Stream<Integer> json() {
+    return Stream.empty();
+  }
+
+  @Override
+  protected Stream<Integer> retry(String id, BasicType type, JsonNode value) {
+    return Stream.of(Integer.parseUnsignedInt(id));
+  }
+
+  @Override
+  public Stream<Integer> string() {
+    return Stream.empty();
+  }
+
+  @Override
+  protected Stream<Integer> dictionary(Stream<Stream<Integer>> entries) {
+    return entries.flatMap(Function.identity());
+  }
+
+  @Override
+  protected Stream<Integer> entry(String key, InputType valueType, JsonNode value) {
+    return valueType.apply(new ExtractRetryValues(mapper, value));
+  }
+
+  @Override
+  protected Stream<Integer> entry(
+      InputType keyType, JsonNode key, InputType valueType, JsonNode value) {
+    return Stream.concat(
+        keyType.apply(new ExtractRetryValues(mapper, key)),
+        valueType.apply(new ExtractRetryValues(mapper, value)));
+  }
+
+  @Override
+  protected Stream<Integer> external(
+      InputProvisionFormat format, JsonNode input, ExternalId[] externalIds) {
+    return Stream.empty();
+  }
+
+  @Override
+  protected Stream<Integer> internal(InputProvisionFormat format, String id) {
+    return Stream.empty();
+  }
+
+  @Override
+  protected Stream<Integer> list(int index, InputType type, JsonNode value) {
+    return type.apply(new ExtractRetryValues(mapper, value));
+  }
+
+  @Override
+  protected ObjectMapper mapper() {
+    return mapper;
+  }
+
+  @Override
+  protected Stream<Integer> nullValue() {
+    return Stream.empty();
+  }
+
+  @Override
+  protected Stream<Integer> object(String fieldName, InputType type, JsonNode value) {
+    return type.apply(new ExtractRetryValues(mapper, value));
+  }
+
+  @Override
+  protected Stream<Integer> pair(
+      InputType left, JsonNode leftValue, InputType right, JsonNode rightValue) {
+    return Stream.concat(
+        left.apply(new ExtractRetryValues(mapper, leftValue)),
+        right.apply(new ExtractRetryValues(mapper, rightValue)));
+  }
+
+  @Override
+  protected Stream<Integer> tuple(int index, InputType type, JsonNode value) {
+    return type.apply(new ExtractRetryValues(mapper, value));
+  }
+
+  @Override
+  protected Stream<Integer> unionChild(InputType value, JsonNode contents) {
+    return value.apply(new ExtractRetryValues(mapper, contents));
+  }
+}

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/OutputType.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/OutputType.java
@@ -212,10 +212,6 @@ public abstract class OutputType {
   }
 
   public static final class JacksonSerializer extends JsonSerializer<OutputType> {
-    private interface Printer {
-      void print(JsonGenerator jsonGenerator) throws IOException;
-    }
-
     @Override
     public void serialize(
         OutputType outputType, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/Printer.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/Printer.java
@@ -1,0 +1,8 @@
+package ca.on.oicr.gsi.vidarr;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import java.io.IOException;
+
+interface Printer {
+  void print(JsonGenerator jsonGenerator) throws IOException;
+}

--- a/vidarr-pluginapi/src/test/java/ca/on/oicr/gsi/vidarr/RetryInputTypeTest.java
+++ b/vidarr-pluginapi/src/test/java/ca/on/oicr/gsi/vidarr/RetryInputTypeTest.java
@@ -1,0 +1,45 @@
+package ca.on.oicr.gsi.vidarr;
+
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+
+public class RetryInputTypeTest extends InputTypeTest {
+
+  private static final String RETRY_TYPE = "{\"is\":\"retry\",\"inner\":\"%s\"}";
+
+  @Override
+  public void testSerialize() {
+    for (final var type : BasicTypeTest.primitiveTypes.entrySet()) {
+      serializeTester(String.format(RETRY_TYPE, type.getValue()), InputType.retry(type.getKey()));
+    }
+  }
+
+  @Test
+  public void testCreateNullThrows() {
+    ThrowingRunnable throwingRunnable = () -> InputType.retry(null);
+    Assert.assertThrows(NullPointerException.class, throwingRunnable);
+  }
+
+  @Override
+  public void testDeserialize() {
+    for (final var type : BasicTypeTest.primitiveTypes.entrySet()) {
+      deserializeTester(InputType.retry(type.getKey()), String.format(RETRY_TYPE, type.getValue()));
+    }
+  }
+
+  @Override
+  public void testEquals() {
+    InputType obj1 = InputType.retry(BasicType.INTEGER),
+        obj2 = InputType.retry(BasicType.INTEGER),
+        objDifferent = InputType.retry(BasicType.BOOLEAN),
+        integer = InputType.INTEGER;
+
+    Assert.assertEquals(obj1, obj1);
+    Assert.assertEquals(obj2, obj1);
+    Assert.assertNotEquals(integer, obj1);
+    Assert.assertNotEquals(null, obj1);
+    Assert.assertNotEquals(objDifferent, obj1);
+  }
+}

--- a/vidarr-server/src/main/resources/db/migration/V0016__retry.sql
+++ b/vidarr-server/src/main/resources/db/migration/V0016__retry.sql
@@ -1,0 +1,2 @@
+ALTER TABLE active_workflow_run ADD COLUMN real_input_index INTEGER NOT NULL DEFAULT 0;
+UPDATE active_workflow_run SET real_input = json_build_array(real_input) WHERE real_input IS NOT NULL;


### PR DESCRIPTION
This adds a new type to workflows that allows a workflow to be automatically
restarted with different parameters. The goal would be to allow workflows that
fail to run with more memory or larger timeouts automatically.

Jira ticket:

- [X] Includes a change file
- [ ] Updates developer documentation

