### PR TITLE
[GP-3473] Store ProvisionIn correctly, don't take out recovery

### DIFF
--- a/changes/fix_provisionin_log.md
+++ b/changes/fix_provisionin_log.md
@@ -1,0 +1,1 @@
+Fixes Provision In phase not logging recovery information in a useable format.

--- a/changes/fix_recover.md
+++ b/changes/fix_recover.md
@@ -1,0 +1,1 @@
+Fixes uncaught exceptions interrupting db-backed recovery.

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/PrepareInputProvisioning.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/PrepareInputProvisioning.java
@@ -9,386 +9,391 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-/** Start the input provisioning tasks */
+/**
+ * Start the input provisioning tasks
+ */
 final class PrepareInputProvisioning implements InputType.Visitor<JsonNode> {
 
-  public static class ProvisionInMonitor
-      extends WrappedMonitor<List<JsonPath>, JsonNode, JsonMutation> {
+    public static class ProvisionInMonitor
+            extends WrappedMonitor<List<JsonPath>, JsonNode, JsonMutation> {
 
-    public ProvisionInMonitor(
-        List<JsonPath> jsonPath, WorkMonitor<JsonMutation, JsonNode> monitor) {
-      super(jsonPath, monitor);
+        public ProvisionInMonitor(
+                List<JsonPath> jsonPath, WorkMonitor<JsonMutation, JsonNode> monitor) {
+            super(jsonPath, monitor);
+        }
+
+        @Override
+        protected JsonMutation mix(List<JsonPath> accessory, JsonNode result) {
+            return new JsonMutation(result, accessory.stream());
+        }
+    }
+
+    private final Consumer<TaskStarter<JsonMutation>> consumer;
+    private final JsonNode input;
+    private final List<JsonPath> jsonPath;
+    private final FileResolver resolver;
+    private final Map<Integer, List<Consumer<ObjectNode>>> retryModifications;
+    private final Target target;
+
+    public PrepareInputProvisioning(
+            Target target,
+            JsonNode input,
+            Stream<JsonPath> jsonPath,
+            FileResolver resolver,
+            Consumer<TaskStarter<JsonMutation>> consumer,
+            Map<Integer, List<Consumer<ObjectNode>>> retryModifications) {
+        this.target = target;
+        this.input = input;
+        this.jsonPath = jsonPath.collect(Collectors.toList());
+        this.resolver = resolver;
+        this.consumer = consumer;
+        this.retryModifications = retryModifications;
     }
 
     @Override
-    protected JsonMutation mix(List<JsonPath> accessory, JsonNode result) {
-      return new JsonMutation(result, accessory.stream());
-    }
-  }
-
-  private final Consumer<TaskStarter<JsonMutation>> consumer;
-  private final JsonNode input;
-  private final List<JsonPath> jsonPath;
-  private final FileResolver resolver;
-  private final Map<Integer, List<Consumer<ObjectNode>>> retryModifications;
-  private final Target target;
-
-  public PrepareInputProvisioning(
-      Target target,
-      JsonNode input,
-      Stream<JsonPath> jsonPath,
-      FileResolver resolver,
-      Consumer<TaskStarter<JsonMutation>> consumer,
-      Map<Integer, List<Consumer<ObjectNode>>> retryModifications) {
-    this.target = target;
-    this.input = input;
-    this.jsonPath = jsonPath.collect(Collectors.toList());
-    this.resolver = resolver;
-    this.consumer = consumer;
-    this.retryModifications = retryModifications;
-  }
-
-  @Override
-  public JsonNode bool() {
-    if (input.isBoolean()) {
-      return input;
-    } else {
-      throw new IllegalArgumentException();
-    }
-  }
-
-  @Override
-  public JsonNode date() {
-    if (input.isIntegralNumber() || input.isTextual()) {
-      return input;
-    } else {
-      throw new IllegalArgumentException();
-    }
-  }
-
-  @Override
-  public JsonNode dictionary(InputType key, InputType value) {
-    if (input.isObject() && key == InputType.STRING) {
-      final var output = JsonNodeFactory.instance.objectNode();
-      final var iterator = input.fields();
-      while (iterator.hasNext()) {
-        final var entry = iterator.next();
-        output.set(
-            entry.getKey(),
-            value.apply(
-                new PrepareInputProvisioning(
-                    target,
-                    entry.getValue(),
-                    Stream.concat(jsonPath.stream(), Stream.of(JsonPath.object(entry.getKey()))),
-                    resolver,
-                    consumer,
-                    retryModifications)));
-      }
-      return output;
-    } else if (input.isArray()) {
-      final var output = JsonNodeFactory.instance.arrayNode(input.size());
-      for (var i = 0; i < input.size(); i++) {
-        final var outputEntry = JsonNodeFactory.instance.arrayNode(2);
-        final var inputEntry = input.get(i);
-        if (!inputEntry.isArray() || inputEntry.size() != 2) {
-          throw new IllegalArgumentException();
+    public JsonNode bool() {
+        if (input.isBoolean()) {
+            return input;
+        } else {
+            throw new IllegalArgumentException();
         }
-        outputEntry.add(
-            key.apply(
-                new PrepareInputProvisioning(
-                    target,
-                    inputEntry.get(0),
-                    Stream.concat(
-                        jsonPath.stream(), Stream.of(JsonPath.array(i), JsonPath.array(0))),
-                    resolver,
-                    consumer,
-                    retryModifications)));
-        outputEntry.add(
-            key.apply(
-                new PrepareInputProvisioning(
-                    target,
-                    inputEntry.get(1),
-                    Stream.concat(
-                        jsonPath.stream(), Stream.of(JsonPath.array(i), JsonPath.array(1))),
-                    resolver,
-                    consumer,
-                    retryModifications)));
-        output.add(outputEntry);
-      }
-      return output;
-    } else {
-      throw new IllegalArgumentException();
-    }
-  }
-
-  @Override
-  public JsonNode directory() {
-    return handle(InputProvisionFormat.DIRECTORY);
-  }
-
-  @Override
-  public JsonNode file() {
-    return handle(InputProvisionFormat.FILE);
-  }
-
-  @Override
-  public JsonNode floating() {
-    if (input.isNumber()) {
-      return input;
-    } else {
-      throw new IllegalArgumentException();
-    }
-  }
-
-  private JsonNode handle(InputProvisionFormat format) {
-    final var handler = target.provisionerFor(format);
-    if (handler == null) {
-      throw new UnsupportedOperationException("No handler for " + format.name());
-    }
-    if (input.isObject() && input.has("type") && input.get("type").isTextual()) {
-      switch (input.get("type").asText()) {
-        case "EXTERNAL":
-          consumer.accept(
-              (language, workflowId, monitor) ->
-                  new Pair<>(
-                      format.name(),
-                      handler.provisionExternal(
-                          language,
-                          input.get("contents").get("configuration"),
-                          new ProvisionInMonitor(jsonPath, monitor))));
-          break;
-        case "INTERNAL":
-          if (input.has("contents")
-              && input.get("contents").isArray()
-              && input.get("contents").size() == 1
-              && input.get("contents").get(0).isTextual()) {
-            final var id = input.get("contents").get(0).asText();
-            final var filePath = resolver.pathForId(id).map(FileMetadata::path).orElseThrow();
-            consumer.accept(
-                (language, workflowId, monitor) ->
-                    new Pair<>(
-                        format.name(),
-                        handler.provision(
-                            language, id, filePath, new ProvisionInMonitor(jsonPath, monitor))));
-          } else {
-            throw new IllegalArgumentException("Invalid input file for BY_ID");
-          }
-          break;
-      }
     }
 
-    return NullNode.getInstance();
-  }
-
-  @Override
-  public JsonNode integer() {
-    if (input.isIntegralNumber()) {
-      return input;
-    } else {
-      throw new IllegalArgumentException();
+    @Override
+    public JsonNode date() {
+        if (input.isIntegralNumber() || input.isTextual()) {
+            return input;
+        } else {
+            throw new IllegalArgumentException();
+        }
     }
-  }
 
-  @Override
-  public JsonNode json() {
-    return input;
-  }
-
-  @Override
-  public JsonNode list(InputType inner) {
-    if (input.isArray()) {
-      final var output = JsonNodeFactory.instance.arrayNode(input.size());
-      for (var i = 0; i < input.size(); i++) {
-        output.add(
-            inner.apply(
-                new PrepareInputProvisioning(
-                    target,
-                    input.get(i),
-                    Stream.concat(jsonPath.stream(), Stream.of(JsonPath.array(i))),
-                    resolver,
-                    consumer,
-                    retryModifications)));
-      }
-      return output;
-    } else {
-      throw new IllegalArgumentException();
-    }
-  }
-
-  @Override
-  public JsonNode object(Stream<Pair<String, InputType>> contents) {
-    if (input.isObject()) {
-      final var output = JsonNodeFactory.instance.objectNode();
-      contents.forEach(
-          p ->
-              output.set(
-                  p.first(),
-                  p.second()
-                      .apply(
-                          new PrepareInputProvisioning(
-                              target,
-                              input.get(p.first()),
-                              Stream.concat(
-                                  jsonPath.stream(), Stream.of(JsonPath.object(p.first()))),
-                              resolver,
-                              consumer,
-                              retryModifications))));
-      return output;
-    } else {
-      contents.close();
-      throw new IllegalArgumentException();
-    }
-  }
-
-  @Override
-  public JsonNode optional(InputType inner) {
-    if (input.isNull()) {
-      return input;
-    } else {
-      return inner.apply(this);
-    }
-  }
-
-  @Override
-  public JsonNode pair(InputType left, InputType right) {
-    if (input.isArray()) {
-      if (input.size() == 2) {
-        final var output = JsonNodeFactory.instance.objectNode();
-        output.set(
-            "left",
-            left.apply(
-                new PrepareInputProvisioning(
-                    target,
-                    input.get(0),
-                    Stream.concat(jsonPath.stream(), Stream.of(JsonPath.object("left"))),
-                    resolver,
-                    consumer,
-                    retryModifications)));
-        output.set(
-            "right",
-            right.apply(
-                new PrepareInputProvisioning(
-                    target,
-                    input.get(1),
-                    Stream.concat(jsonPath.stream(), Stream.of(JsonPath.object("right"))),
-                    resolver,
-                    consumer,
-                    retryModifications)));
-        return output;
-      } else {
-        throw new IllegalArgumentException("Pair with incorrect number of arguments");
-      }
-    } else if (input.isObject()) {
-      if (input.has("left") && input.has("right")) {
-        final var output = JsonNodeFactory.instance.objectNode();
-        output.set(
-            "left",
-            left.apply(
-                new PrepareInputProvisioning(
-                    target,
-                    input.get("left"),
-                    Stream.concat(jsonPath.stream(), Stream.of(JsonPath.object("left"))),
-                    resolver,
-                    consumer,
-                    retryModifications)));
-        output.set(
-            "right",
-            right.apply(
-                new PrepareInputProvisioning(
-                    target,
-                    input.get("right"),
-                    Stream.concat(jsonPath.stream(), Stream.of(JsonPath.object("right"))),
-                    resolver,
-                    consumer,
-                    retryModifications)));
-        return output;
-
-      } else {
-        throw new IllegalArgumentException("Pair with incorrect fields");
-      }
-
-    } else {
-      throw new IllegalArgumentException();
-    }
-  }
-
-  @Override
-  public JsonNode retry(BasicType inner) {
-    final var fields = input.fields();
-    while (fields.hasNext()) {
-      final var field = fields.next();
-      retryModifications
-          .get(Integer.parseUnsignedInt(field.getKey()))
-          .add(new ApplyRetry(jsonPath, field.getValue()));
-    }
-    return NullNode.getInstance();
-  }
-
-  @Override
-  public JsonNode string() {
-    if (input.isTextual()) {
-      return input;
-    } else {
-      throw new IllegalArgumentException();
-    }
-  }
-
-  @Override
-  public JsonNode taggedUnion(Stream<Map.Entry<String, InputType>> elements) {
-    if (input.isObject() && input.get("type").isTextual()) {
-      final var type = input.get("type").asText();
-      return elements
-          .filter(e -> e.getKey().equals(type))
-          .findFirst()
-          .map(
-              e ->
-                  e.getValue()
-                      .apply(
-                          new PrepareInputProvisioning(
-                              target,
-                              input.get("contents"),
-                              jsonPath.stream(),
-                              resolver,
-                              consumer,
-                              retryModifications)))
-          .orElseThrow();
-    } else {
-      throw new IllegalArgumentException();
-    }
-  }
-
-  @Override
-  public JsonNode tuple(Stream<InputType> contents) {
-    if (input.isArray()) {
-      final var output = JsonNodeFactory.instance.arrayNode(input.size());
-      contents.forEach(
-          new Consumer<>() {
-            private int index;
-
-            @Override
-            public void accept(InputType t) {
-              output.add(
-                  t.apply(
-                      new PrepareInputProvisioning(
-                          target,
-                          input.get(index),
-                          Stream.concat(jsonPath.stream(), Stream.of(JsonPath.array(index))),
-                          resolver,
-                          consumer,
-                          retryModifications)));
-              index++;
+    @Override
+    public JsonNode dictionary(InputType key, InputType value) {
+        if (input.isObject() && key == InputType.STRING) {
+            final var output = JsonNodeFactory.instance.objectNode();
+            final var iterator = input.fields();
+            while (iterator.hasNext()) {
+                final var entry = iterator.next();
+                output.set(
+                        entry.getKey(),
+                        value.apply(
+                                new PrepareInputProvisioning(
+                                        target,
+                                        entry.getValue(),
+                                        Stream.concat(jsonPath.stream(), Stream.of(JsonPath.object(entry.getKey()))),
+                                        resolver,
+                                        consumer,
+                                        retryModifications)));
             }
-          });
-      return output;
-    } else {
-      contents.close();
-      throw new IllegalArgumentException();
+            return output;
+        } else if (input.isArray()) {
+            final var output = JsonNodeFactory.instance.arrayNode(input.size());
+            for (var i = 0; i < input.size(); i++) {
+                final var outputEntry = JsonNodeFactory.instance.arrayNode(2);
+                final var inputEntry = input.get(i);
+                if (!inputEntry.isArray() || inputEntry.size() != 2) {
+                    throw new IllegalArgumentException();
+                }
+                outputEntry.add(
+                        key.apply(
+                                new PrepareInputProvisioning(
+                                        target,
+                                        inputEntry.get(0),
+                                        Stream.concat(
+                                                jsonPath.stream(), Stream.of(JsonPath.array(i), JsonPath.array(0))),
+                                        resolver,
+                                        consumer,
+                                        retryModifications)));
+                outputEntry.add(
+                        key.apply(
+                                new PrepareInputProvisioning(
+                                        target,
+                                        inputEntry.get(1),
+                                        Stream.concat(
+                                                jsonPath.stream(), Stream.of(JsonPath.array(i), JsonPath.array(1))),
+                                        resolver,
+                                        consumer,
+                                        retryModifications)));
+                output.add(outputEntry);
+            }
+            return output;
+        } else {
+            throw new IllegalArgumentException();
+        }
     }
-  }
+
+    @Override
+    public JsonNode directory() {
+        return handle(InputProvisionFormat.DIRECTORY);
+    }
+
+    @Override
+    public JsonNode file() {
+        return handle(InputProvisionFormat.FILE);
+    }
+
+    @Override
+    public JsonNode floating() {
+        if (input.isNumber()) {
+            return input;
+        } else {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    private JsonNode handle(InputProvisionFormat format) {
+        final var handler = target.provisionerFor(format);
+        if (handler == null) {
+            throw new UnsupportedOperationException("No handler for " + format.name());
+        }
+        if (input.isObject() && input.has("type") && input.get("type").isTextual()) {
+            switch (input.get("type").asText()) {
+                case "EXTERNAL":
+                    consumer.accept(
+                            WrappedMonitor.start(
+                                    jsonPath,
+                                    ProvisionInMonitor::new,
+                                    (language, workflowId, monitor) ->
+                                            new Pair<>(
+                                                    format.name(),
+                                                    handler.provisionExternal(
+                                                            language, input.get("contents").get("configuration"), monitor))));
+                    break;
+                case "INTERNAL":
+                    if (input.has("contents")
+                            && input.get("contents").isArray()
+                            && input.get("contents").size() == 1
+                            && input.get("contents").get(0).isTextual()) {
+                        final var id = input.get("contents").get(0).asText();
+                        final var filePath = resolver.pathForId(id).map(FileMetadata::path).orElseThrow();
+                        consumer.accept(
+                                WrappedMonitor.start(
+                                        jsonPath,
+                                        ProvisionInMonitor::new,
+                                        (language, workflowId, monitor) ->
+                                                new Pair<>(
+                                                        format.name(), handler.provision(language, id, filePath, monitor))));
+                    } else {
+                        throw new IllegalArgumentException("Invalid input file for BY_ID");
+                    }
+                    break;
+            }
+        }
+
+        return NullNode.getInstance();
+    }
+
+    @Override
+    public JsonNode integer() {
+        if (input.isIntegralNumber()) {
+            return input;
+        } else {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    @Override
+    public JsonNode json() {
+        return input;
+    }
+
+    @Override
+    public JsonNode list(InputType inner) {
+        if (input.isArray()) {
+            final var output = JsonNodeFactory.instance.arrayNode(input.size());
+            for (var i = 0; i < input.size(); i++) {
+                output.add(
+                        inner.apply(
+                                new PrepareInputProvisioning(
+                                        target,
+                                        input.get(i),
+                                        Stream.concat(jsonPath.stream(), Stream.of(JsonPath.array(i))),
+                                        resolver,
+                                        consumer,
+                                        retryModifications)));
+            }
+            return output;
+        } else {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    @Override
+    public JsonNode object(Stream<Pair<String, InputType>> contents) {
+        if (input.isObject()) {
+            final var output = JsonNodeFactory.instance.objectNode();
+            contents.forEach(
+                    p ->
+                            output.set(
+                                    p.first(),
+                                    p.second()
+                                            .apply(
+                                                    new PrepareInputProvisioning(
+                                                            target,
+                                                            input.get(p.first()),
+                                                            Stream.concat(
+                                                                    jsonPath.stream(), Stream.of(JsonPath.object(p.first()))),
+                                                            resolver,
+                                                            consumer,
+                                                            retryModifications))));
+            return output;
+        } else {
+            contents.close();
+            throw new IllegalArgumentException();
+        }
+    }
+
+    @Override
+    public JsonNode optional(InputType inner) {
+        if (input.isNull()) {
+            return input;
+        } else {
+            return inner.apply(this);
+        }
+    }
+
+    @Override
+    public JsonNode pair(InputType left, InputType right) {
+        if (input.isArray()) {
+            if (input.size() == 2) {
+                final var output = JsonNodeFactory.instance.objectNode();
+                output.set(
+                        "left",
+                        left.apply(
+                                new PrepareInputProvisioning(
+                                        target,
+                                        input.get(0),
+                                        Stream.concat(jsonPath.stream(), Stream.of(JsonPath.object("left"))),
+                                        resolver,
+                                        consumer,
+                                        retryModifications)));
+                output.set(
+                        "right",
+                        right.apply(
+                                new PrepareInputProvisioning(
+                                        target,
+                                        input.get(1),
+                                        Stream.concat(jsonPath.stream(), Stream.of(JsonPath.object("right"))),
+                                        resolver,
+                                        consumer,
+                                        retryModifications)));
+                return output;
+            } else {
+                throw new IllegalArgumentException("Pair with incorrect number of arguments");
+            }
+        } else if (input.isObject()) {
+            if (input.has("left") && input.has("right")) {
+                final var output = JsonNodeFactory.instance.objectNode();
+                output.set(
+                        "left",
+                        left.apply(
+                                new PrepareInputProvisioning(
+                                        target,
+                                        input.get("left"),
+                                        Stream.concat(jsonPath.stream(), Stream.of(JsonPath.object("left"))),
+                                        resolver,
+                                        consumer,
+                                        retryModifications)));
+                output.set(
+                        "right",
+                        right.apply(
+                                new PrepareInputProvisioning(
+                                        target,
+                                        input.get("right"),
+                                        Stream.concat(jsonPath.stream(), Stream.of(JsonPath.object("right"))),
+                                        resolver,
+                                        consumer,
+                                        retryModifications)));
+                return output;
+
+            } else {
+                throw new IllegalArgumentException("Pair with incorrect fields");
+            }
+
+        } else {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    @Override
+    public JsonNode retry(BasicType inner) {
+        final var fields = input.fields();
+        while (fields.hasNext()) {
+            final var field = fields.next();
+            retryModifications
+                    .get(Integer.parseUnsignedInt(field.getKey()))
+                    .add(new ApplyRetry(jsonPath, field.getValue()));
+        }
+        return NullNode.getInstance();
+    }
+
+    @Override
+    public JsonNode string() {
+        if (input.isTextual()) {
+            return input;
+        } else {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    @Override
+    public JsonNode taggedUnion(Stream<Map.Entry<String, InputType>> elements) {
+        if (input.isObject() && input.get("type").isTextual()) {
+            final var type = input.get("type").asText();
+            return elements
+                    .filter(e -> e.getKey().equals(type))
+                    .findFirst()
+                    .map(
+                            e ->
+                                    e.getValue()
+                                            .apply(
+                                                    new PrepareInputProvisioning(
+                                                            target,
+                                                            input.get("contents"),
+                                                            jsonPath.stream(),
+                                                            resolver,
+                                                            consumer,
+                                                            retryModifications)))
+                    .orElseThrow();
+        } else {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    @Override
+    public JsonNode tuple(Stream<InputType> contents) {
+        if (input.isArray()) {
+            final var output = JsonNodeFactory.instance.arrayNode(input.size());
+            contents.forEach(
+                    new Consumer<>() {
+                        private int index;
+
+                        @Override
+                        public void accept(InputType t) {
+                            output.add(
+                                    t.apply(
+                                            new PrepareInputProvisioning(
+                                                    target,
+                                                    input.get(index),
+                                                    Stream.concat(jsonPath.stream(), Stream.of(JsonPath.array(index))),
+                                                    resolver,
+                                                    consumer,
+                                                    retryModifications)));
+                            index++;
+                        }
+                    });
+            return output;
+        } else {
+            contents.close();
+            throw new IllegalArgumentException();
+        }
+    }
 }

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/PrepareInputProvisioning.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/PrepareInputProvisioning.java
@@ -9,391 +9,388 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-/**
- * Start the input provisioning tasks
- */
+/** Start the input provisioning tasks */
 final class PrepareInputProvisioning implements InputType.Visitor<JsonNode> {
 
-    public static class ProvisionInMonitor
-            extends WrappedMonitor<List<JsonPath>, JsonNode, JsonMutation> {
+  public static class ProvisionInMonitor
+      extends WrappedMonitor<List<JsonPath>, JsonNode, JsonMutation> {
 
-        public ProvisionInMonitor(
-                List<JsonPath> jsonPath, WorkMonitor<JsonMutation, JsonNode> monitor) {
-            super(jsonPath, monitor);
-        }
-
-        @Override
-        protected JsonMutation mix(List<JsonPath> accessory, JsonNode result) {
-            return new JsonMutation(result, accessory.stream());
-        }
-    }
-
-    private final Consumer<TaskStarter<JsonMutation>> consumer;
-    private final JsonNode input;
-    private final List<JsonPath> jsonPath;
-    private final FileResolver resolver;
-    private final Map<Integer, List<Consumer<ObjectNode>>> retryModifications;
-    private final Target target;
-
-    public PrepareInputProvisioning(
-            Target target,
-            JsonNode input,
-            Stream<JsonPath> jsonPath,
-            FileResolver resolver,
-            Consumer<TaskStarter<JsonMutation>> consumer,
-            Map<Integer, List<Consumer<ObjectNode>>> retryModifications) {
-        this.target = target;
-        this.input = input;
-        this.jsonPath = jsonPath.collect(Collectors.toList());
-        this.resolver = resolver;
-        this.consumer = consumer;
-        this.retryModifications = retryModifications;
+    public ProvisionInMonitor(
+        List<JsonPath> jsonPath, WorkMonitor<JsonMutation, JsonNode> monitor) {
+      super(jsonPath, monitor);
     }
 
     @Override
-    public JsonNode bool() {
-        if (input.isBoolean()) {
-            return input;
-        } else {
-            throw new IllegalArgumentException();
+    protected JsonMutation mix(List<JsonPath> accessory, JsonNode result) {
+      return new JsonMutation(result, accessory.stream());
+    }
+  }
+
+  private final Consumer<TaskStarter<JsonMutation>> consumer;
+  private final JsonNode input;
+  private final List<JsonPath> jsonPath;
+  private final FileResolver resolver;
+  private final Map<Integer, List<Consumer<ObjectNode>>> retryModifications;
+  private final Target target;
+
+  public PrepareInputProvisioning(
+      Target target,
+      JsonNode input,
+      Stream<JsonPath> jsonPath,
+      FileResolver resolver,
+      Consumer<TaskStarter<JsonMutation>> consumer,
+      Map<Integer, List<Consumer<ObjectNode>>> retryModifications) {
+    this.target = target;
+    this.input = input;
+    this.jsonPath = jsonPath.collect(Collectors.toList());
+    this.resolver = resolver;
+    this.consumer = consumer;
+    this.retryModifications = retryModifications;
+  }
+
+  @Override
+  public JsonNode bool() {
+    if (input.isBoolean()) {
+      return input;
+    } else {
+      throw new IllegalArgumentException();
+    }
+  }
+
+  @Override
+  public JsonNode date() {
+    if (input.isIntegralNumber() || input.isTextual()) {
+      return input;
+    } else {
+      throw new IllegalArgumentException();
+    }
+  }
+
+  @Override
+  public JsonNode dictionary(InputType key, InputType value) {
+    if (input.isObject() && key == InputType.STRING) {
+      final var output = JsonNodeFactory.instance.objectNode();
+      final var iterator = input.fields();
+      while (iterator.hasNext()) {
+        final var entry = iterator.next();
+        output.set(
+            entry.getKey(),
+            value.apply(
+                new PrepareInputProvisioning(
+                    target,
+                    entry.getValue(),
+                    Stream.concat(jsonPath.stream(), Stream.of(JsonPath.object(entry.getKey()))),
+                    resolver,
+                    consumer,
+                    retryModifications)));
+      }
+      return output;
+    } else if (input.isArray()) {
+      final var output = JsonNodeFactory.instance.arrayNode(input.size());
+      for (var i = 0; i < input.size(); i++) {
+        final var outputEntry = JsonNodeFactory.instance.arrayNode(2);
+        final var inputEntry = input.get(i);
+        if (!inputEntry.isArray() || inputEntry.size() != 2) {
+          throw new IllegalArgumentException();
         }
+        outputEntry.add(
+            key.apply(
+                new PrepareInputProvisioning(
+                    target,
+                    inputEntry.get(0),
+                    Stream.concat(
+                        jsonPath.stream(), Stream.of(JsonPath.array(i), JsonPath.array(0))),
+                    resolver,
+                    consumer,
+                    retryModifications)));
+        outputEntry.add(
+            key.apply(
+                new PrepareInputProvisioning(
+                    target,
+                    inputEntry.get(1),
+                    Stream.concat(
+                        jsonPath.stream(), Stream.of(JsonPath.array(i), JsonPath.array(1))),
+                    resolver,
+                    consumer,
+                    retryModifications)));
+        output.add(outputEntry);
+      }
+      return output;
+    } else {
+      throw new IllegalArgumentException();
+    }
+  }
+
+  @Override
+  public JsonNode directory() {
+    return handle(InputProvisionFormat.DIRECTORY);
+  }
+
+  @Override
+  public JsonNode file() {
+    return handle(InputProvisionFormat.FILE);
+  }
+
+  @Override
+  public JsonNode floating() {
+    if (input.isNumber()) {
+      return input;
+    } else {
+      throw new IllegalArgumentException();
+    }
+  }
+
+  private JsonNode handle(InputProvisionFormat format) {
+    final var handler = target.provisionerFor(format);
+    if (handler == null) {
+      throw new UnsupportedOperationException("No handler for " + format.name());
+    }
+    if (input.isObject() && input.has("type") && input.get("type").isTextual()) {
+      switch (input.get("type").asText()) {
+        case "EXTERNAL":
+          consumer.accept(
+              WrappedMonitor.start(
+                  jsonPath,
+                  ProvisionInMonitor::new,
+                  (language, workflowId, monitor) ->
+                      new Pair<>(
+                          format.name(),
+                          handler.provisionExternal(
+                              language, input.get("contents").get("configuration"), monitor))));
+          break;
+        case "INTERNAL":
+          if (input.has("contents")
+              && input.get("contents").isArray()
+              && input.get("contents").size() == 1
+              && input.get("contents").get(0).isTextual()) {
+            final var id = input.get("contents").get(0).asText();
+            final var filePath = resolver.pathForId(id).map(FileMetadata::path).orElseThrow();
+            consumer.accept(
+                WrappedMonitor.start(
+                    jsonPath,
+                    ProvisionInMonitor::new,
+                    (language, workflowId, monitor) ->
+                        new Pair<>(
+                            format.name(), handler.provision(language, id, filePath, monitor))));
+          } else {
+            throw new IllegalArgumentException("Invalid input file for BY_ID");
+          }
+          break;
+      }
     }
 
-    @Override
-    public JsonNode date() {
-        if (input.isIntegralNumber() || input.isTextual()) {
-            return input;
-        } else {
-            throw new IllegalArgumentException();
-        }
-    }
+    return NullNode.getInstance();
+  }
 
-    @Override
-    public JsonNode dictionary(InputType key, InputType value) {
-        if (input.isObject() && key == InputType.STRING) {
-            final var output = JsonNodeFactory.instance.objectNode();
-            final var iterator = input.fields();
-            while (iterator.hasNext()) {
-                final var entry = iterator.next();
-                output.set(
-                        entry.getKey(),
-                        value.apply(
-                                new PrepareInputProvisioning(
-                                        target,
-                                        entry.getValue(),
-                                        Stream.concat(jsonPath.stream(), Stream.of(JsonPath.object(entry.getKey()))),
-                                        resolver,
-                                        consumer,
-                                        retryModifications)));
+  @Override
+  public JsonNode integer() {
+    if (input.isIntegralNumber()) {
+      return input;
+    } else {
+      throw new IllegalArgumentException();
+    }
+  }
+
+  @Override
+  public JsonNode json() {
+    return input;
+  }
+
+  @Override
+  public JsonNode list(InputType inner) {
+    if (input.isArray()) {
+      final var output = JsonNodeFactory.instance.arrayNode(input.size());
+      for (var i = 0; i < input.size(); i++) {
+        output.add(
+            inner.apply(
+                new PrepareInputProvisioning(
+                    target,
+                    input.get(i),
+                    Stream.concat(jsonPath.stream(), Stream.of(JsonPath.array(i))),
+                    resolver,
+                    consumer,
+                    retryModifications)));
+      }
+      return output;
+    } else {
+      throw new IllegalArgumentException();
+    }
+  }
+
+  @Override
+  public JsonNode object(Stream<Pair<String, InputType>> contents) {
+    if (input.isObject()) {
+      final var output = JsonNodeFactory.instance.objectNode();
+      contents.forEach(
+          p ->
+              output.set(
+                  p.first(),
+                  p.second()
+                      .apply(
+                          new PrepareInputProvisioning(
+                              target,
+                              input.get(p.first()),
+                              Stream.concat(
+                                  jsonPath.stream(), Stream.of(JsonPath.object(p.first()))),
+                              resolver,
+                              consumer,
+                              retryModifications))));
+      return output;
+    } else {
+      contents.close();
+      throw new IllegalArgumentException();
+    }
+  }
+
+  @Override
+  public JsonNode optional(InputType inner) {
+    if (input.isNull()) {
+      return input;
+    } else {
+      return inner.apply(this);
+    }
+  }
+
+  @Override
+  public JsonNode pair(InputType left, InputType right) {
+    if (input.isArray()) {
+      if (input.size() == 2) {
+        final var output = JsonNodeFactory.instance.objectNode();
+        output.set(
+            "left",
+            left.apply(
+                new PrepareInputProvisioning(
+                    target,
+                    input.get(0),
+                    Stream.concat(jsonPath.stream(), Stream.of(JsonPath.object("left"))),
+                    resolver,
+                    consumer,
+                    retryModifications)));
+        output.set(
+            "right",
+            right.apply(
+                new PrepareInputProvisioning(
+                    target,
+                    input.get(1),
+                    Stream.concat(jsonPath.stream(), Stream.of(JsonPath.object("right"))),
+                    resolver,
+                    consumer,
+                    retryModifications)));
+        return output;
+      } else {
+        throw new IllegalArgumentException("Pair with incorrect number of arguments");
+      }
+    } else if (input.isObject()) {
+      if (input.has("left") && input.has("right")) {
+        final var output = JsonNodeFactory.instance.objectNode();
+        output.set(
+            "left",
+            left.apply(
+                new PrepareInputProvisioning(
+                    target,
+                    input.get("left"),
+                    Stream.concat(jsonPath.stream(), Stream.of(JsonPath.object("left"))),
+                    resolver,
+                    consumer,
+                    retryModifications)));
+        output.set(
+            "right",
+            right.apply(
+                new PrepareInputProvisioning(
+                    target,
+                    input.get("right"),
+                    Stream.concat(jsonPath.stream(), Stream.of(JsonPath.object("right"))),
+                    resolver,
+                    consumer,
+                    retryModifications)));
+        return output;
+
+      } else {
+        throw new IllegalArgumentException("Pair with incorrect fields");
+      }
+
+    } else {
+      throw new IllegalArgumentException();
+    }
+  }
+
+  @Override
+  public JsonNode retry(BasicType inner) {
+    final var fields = input.fields();
+    while (fields.hasNext()) {
+      final var field = fields.next();
+      retryModifications
+          .get(Integer.parseUnsignedInt(field.getKey()))
+          .add(new ApplyRetry(jsonPath, field.getValue()));
+    }
+    return NullNode.getInstance();
+  }
+
+  @Override
+  public JsonNode string() {
+    if (input.isTextual()) {
+      return input;
+    } else {
+      throw new IllegalArgumentException();
+    }
+  }
+
+  @Override
+  public JsonNode taggedUnion(Stream<Map.Entry<String, InputType>> elements) {
+    if (input.isObject() && input.get("type").isTextual()) {
+      final var type = input.get("type").asText();
+      return elements
+          .filter(e -> e.getKey().equals(type))
+          .findFirst()
+          .map(
+              e ->
+                  e.getValue()
+                      .apply(
+                          new PrepareInputProvisioning(
+                              target,
+                              input.get("contents"),
+                              jsonPath.stream(),
+                              resolver,
+                              consumer,
+                              retryModifications)))
+          .orElseThrow();
+    } else {
+      throw new IllegalArgumentException();
+    }
+  }
+
+  @Override
+  public JsonNode tuple(Stream<InputType> contents) {
+    if (input.isArray()) {
+      final var output = JsonNodeFactory.instance.arrayNode(input.size());
+      contents.forEach(
+          new Consumer<>() {
+            private int index;
+
+            @Override
+            public void accept(InputType t) {
+              output.add(
+                  t.apply(
+                      new PrepareInputProvisioning(
+                          target,
+                          input.get(index),
+                          Stream.concat(jsonPath.stream(), Stream.of(JsonPath.array(index))),
+                          resolver,
+                          consumer,
+                          retryModifications)));
+              index++;
             }
-            return output;
-        } else if (input.isArray()) {
-            final var output = JsonNodeFactory.instance.arrayNode(input.size());
-            for (var i = 0; i < input.size(); i++) {
-                final var outputEntry = JsonNodeFactory.instance.arrayNode(2);
-                final var inputEntry = input.get(i);
-                if (!inputEntry.isArray() || inputEntry.size() != 2) {
-                    throw new IllegalArgumentException();
-                }
-                outputEntry.add(
-                        key.apply(
-                                new PrepareInputProvisioning(
-                                        target,
-                                        inputEntry.get(0),
-                                        Stream.concat(
-                                                jsonPath.stream(), Stream.of(JsonPath.array(i), JsonPath.array(0))),
-                                        resolver,
-                                        consumer,
-                                        retryModifications)));
-                outputEntry.add(
-                        key.apply(
-                                new PrepareInputProvisioning(
-                                        target,
-                                        inputEntry.get(1),
-                                        Stream.concat(
-                                                jsonPath.stream(), Stream.of(JsonPath.array(i), JsonPath.array(1))),
-                                        resolver,
-                                        consumer,
-                                        retryModifications)));
-                output.add(outputEntry);
-            }
-            return output;
-        } else {
-            throw new IllegalArgumentException();
-        }
+          });
+      return output;
+    } else {
+      contents.close();
+      throw new IllegalArgumentException();
     }
-
-    @Override
-    public JsonNode directory() {
-        return handle(InputProvisionFormat.DIRECTORY);
-    }
-
-    @Override
-    public JsonNode file() {
-        return handle(InputProvisionFormat.FILE);
-    }
-
-    @Override
-    public JsonNode floating() {
-        if (input.isNumber()) {
-            return input;
-        } else {
-            throw new IllegalArgumentException();
-        }
-    }
-
-    private JsonNode handle(InputProvisionFormat format) {
-        final var handler = target.provisionerFor(format);
-        if (handler == null) {
-            throw new UnsupportedOperationException("No handler for " + format.name());
-        }
-        if (input.isObject() && input.has("type") && input.get("type").isTextual()) {
-            switch (input.get("type").asText()) {
-                case "EXTERNAL":
-                    consumer.accept(
-                            WrappedMonitor.start(
-                                    jsonPath,
-                                    ProvisionInMonitor::new,
-                                    (language, workflowId, monitor) ->
-                                            new Pair<>(
-                                                    format.name(),
-                                                    handler.provisionExternal(
-                                                            language, input.get("contents").get("configuration"), monitor))));
-                    break;
-                case "INTERNAL":
-                    if (input.has("contents")
-                            && input.get("contents").isArray()
-                            && input.get("contents").size() == 1
-                            && input.get("contents").get(0).isTextual()) {
-                        final var id = input.get("contents").get(0).asText();
-                        final var filePath = resolver.pathForId(id).map(FileMetadata::path).orElseThrow();
-                        consumer.accept(
-                                WrappedMonitor.start(
-                                        jsonPath,
-                                        ProvisionInMonitor::new,
-                                        (language, workflowId, monitor) ->
-                                                new Pair<>(
-                                                        format.name(), handler.provision(language, id, filePath, monitor))));
-                    } else {
-                        throw new IllegalArgumentException("Invalid input file for BY_ID");
-                    }
-                    break;
-            }
-        }
-
-        return NullNode.getInstance();
-    }
-
-    @Override
-    public JsonNode integer() {
-        if (input.isIntegralNumber()) {
-            return input;
-        } else {
-            throw new IllegalArgumentException();
-        }
-    }
-
-    @Override
-    public JsonNode json() {
-        return input;
-    }
-
-    @Override
-    public JsonNode list(InputType inner) {
-        if (input.isArray()) {
-            final var output = JsonNodeFactory.instance.arrayNode(input.size());
-            for (var i = 0; i < input.size(); i++) {
-                output.add(
-                        inner.apply(
-                                new PrepareInputProvisioning(
-                                        target,
-                                        input.get(i),
-                                        Stream.concat(jsonPath.stream(), Stream.of(JsonPath.array(i))),
-                                        resolver,
-                                        consumer,
-                                        retryModifications)));
-            }
-            return output;
-        } else {
-            throw new IllegalArgumentException();
-        }
-    }
-
-    @Override
-    public JsonNode object(Stream<Pair<String, InputType>> contents) {
-        if (input.isObject()) {
-            final var output = JsonNodeFactory.instance.objectNode();
-            contents.forEach(
-                    p ->
-                            output.set(
-                                    p.first(),
-                                    p.second()
-                                            .apply(
-                                                    new PrepareInputProvisioning(
-                                                            target,
-                                                            input.get(p.first()),
-                                                            Stream.concat(
-                                                                    jsonPath.stream(), Stream.of(JsonPath.object(p.first()))),
-                                                            resolver,
-                                                            consumer,
-                                                            retryModifications))));
-            return output;
-        } else {
-            contents.close();
-            throw new IllegalArgumentException();
-        }
-    }
-
-    @Override
-    public JsonNode optional(InputType inner) {
-        if (input.isNull()) {
-            return input;
-        } else {
-            return inner.apply(this);
-        }
-    }
-
-    @Override
-    public JsonNode pair(InputType left, InputType right) {
-        if (input.isArray()) {
-            if (input.size() == 2) {
-                final var output = JsonNodeFactory.instance.objectNode();
-                output.set(
-                        "left",
-                        left.apply(
-                                new PrepareInputProvisioning(
-                                        target,
-                                        input.get(0),
-                                        Stream.concat(jsonPath.stream(), Stream.of(JsonPath.object("left"))),
-                                        resolver,
-                                        consumer,
-                                        retryModifications)));
-                output.set(
-                        "right",
-                        right.apply(
-                                new PrepareInputProvisioning(
-                                        target,
-                                        input.get(1),
-                                        Stream.concat(jsonPath.stream(), Stream.of(JsonPath.object("right"))),
-                                        resolver,
-                                        consumer,
-                                        retryModifications)));
-                return output;
-            } else {
-                throw new IllegalArgumentException("Pair with incorrect number of arguments");
-            }
-        } else if (input.isObject()) {
-            if (input.has("left") && input.has("right")) {
-                final var output = JsonNodeFactory.instance.objectNode();
-                output.set(
-                        "left",
-                        left.apply(
-                                new PrepareInputProvisioning(
-                                        target,
-                                        input.get("left"),
-                                        Stream.concat(jsonPath.stream(), Stream.of(JsonPath.object("left"))),
-                                        resolver,
-                                        consumer,
-                                        retryModifications)));
-                output.set(
-                        "right",
-                        right.apply(
-                                new PrepareInputProvisioning(
-                                        target,
-                                        input.get("right"),
-                                        Stream.concat(jsonPath.stream(), Stream.of(JsonPath.object("right"))),
-                                        resolver,
-                                        consumer,
-                                        retryModifications)));
-                return output;
-
-            } else {
-                throw new IllegalArgumentException("Pair with incorrect fields");
-            }
-
-        } else {
-            throw new IllegalArgumentException();
-        }
-    }
-
-    @Override
-    public JsonNode retry(BasicType inner) {
-        final var fields = input.fields();
-        while (fields.hasNext()) {
-            final var field = fields.next();
-            retryModifications
-                    .get(Integer.parseUnsignedInt(field.getKey()))
-                    .add(new ApplyRetry(jsonPath, field.getValue()));
-        }
-        return NullNode.getInstance();
-    }
-
-    @Override
-    public JsonNode string() {
-        if (input.isTextual()) {
-            return input;
-        } else {
-            throw new IllegalArgumentException();
-        }
-    }
-
-    @Override
-    public JsonNode taggedUnion(Stream<Map.Entry<String, InputType>> elements) {
-        if (input.isObject() && input.get("type").isTextual()) {
-            final var type = input.get("type").asText();
-            return elements
-                    .filter(e -> e.getKey().equals(type))
-                    .findFirst()
-                    .map(
-                            e ->
-                                    e.getValue()
-                                            .apply(
-                                                    new PrepareInputProvisioning(
-                                                            target,
-                                                            input.get("contents"),
-                                                            jsonPath.stream(),
-                                                            resolver,
-                                                            consumer,
-                                                            retryModifications)))
-                    .orElseThrow();
-        } else {
-            throw new IllegalArgumentException();
-        }
-    }
-
-    @Override
-    public JsonNode tuple(Stream<InputType> contents) {
-        if (input.isArray()) {
-            final var output = JsonNodeFactory.instance.arrayNode(input.size());
-            contents.forEach(
-                    new Consumer<>() {
-                        private int index;
-
-                        @Override
-                        public void accept(InputType t) {
-                            output.add(
-                                    t.apply(
-                                            new PrepareInputProvisioning(
-                                                    target,
-                                                    input.get(index),
-                                                    Stream.concat(jsonPath.stream(), Stream.of(JsonPath.array(index))),
-                                                    resolver,
-                                                    consumer,
-                                                    retryModifications)));
-                            index++;
-                        }
-                    });
-            return output;
-        } else {
-            contents.close();
-            throw new IllegalArgumentException();
-        }
-    }
+  }
 }

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
@@ -52,7 +52,6 @@ public abstract class DatabaseBackedProcessor
       Counter.build(
               "vidarr_db_processor_recovery_failure_count",
               "The number of failures in recovering database-backed operations")
-          .labelNames("workflow")
           .register();
 
   public interface DeleteResultHandler<T> {
@@ -746,9 +745,7 @@ public abstract class DatabaseBackedProcessor
                                             "Error recovering workflow run %s: \n",
                                             record.get(WORKFLOW_RUN.HASH_ID));
                                         e.printStackTrace();
-                                        badRecoveryCount
-                                            .labels(record.get(WORKFLOW_RUN.HASH_ID))
-                                            .inc();
+                                        badRecoveryCount.inc();
                                         System.err.println(
                                             "Continuing recovery on next record in database if one exists.");
                                       }

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
@@ -662,6 +662,7 @@ public abstract class DatabaseBackedProcessor
                             targetByName(record.get(ACTIVE_WORKFLOW_RUN.TARGET))
                                 .ifPresent(
                                     target -> {
+                                      try{
                                       if (record.get(ACTIVE_WORKFLOW_RUN.ENGINE_PHASE)
                                           == Phase.WAITING_FOR_RESOURCES) {
                                         final var definition =
@@ -725,17 +726,17 @@ public abstract class DatabaseBackedProcessor
                                         for (final var operation : activeOperations) {
                                           operation.linkTo(workflow);
                                         }
-                                        try {
                                           recover(
                                                   target,
                                                   buildDefinitionFromRecord(context.dsl(), record),
                                                   workflow,
                                                   activeOperations);
-                                        } catch (Exception e){
-                                          System.err.println("That's super bad but we should probably keep going!");
-                                        }
+                                      }
+                                    }catch (Exception e){
+                                      System.err.println("This is really very bad!");
                                       }
                                     }));
+
               });
       connection.commit();
     }

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
@@ -725,11 +725,15 @@ public abstract class DatabaseBackedProcessor
                                         for (final var operation : activeOperations) {
                                           operation.linkTo(workflow);
                                         }
-                                        recover(
-                                            target,
-                                            buildDefinitionFromRecord(context.dsl(), record),
-                                            workflow,
-                                            activeOperations);
+                                        try {
+                                          recover(
+                                                  target,
+                                                  buildDefinitionFromRecord(context.dsl(), record),
+                                                  workflow,
+                                                  activeOperations);
+                                        } catch (Exception e){
+                                          System.err.println("That's super bad but we should probably keep going!");
+                                        }
                                       }
                                     }));
               });


### PR DESCRIPTION
Credit goes to @apmasell for the PrepareInputProvisioning fix, which ensures Provision-In phase tasks log recovery information to the database in a format that is useable by the DatabaseBackedProcessor.
Also wraps Database-backed recovery in a try-catch block within the .forEach() so that issues with a particular recovery task do not interrupt the entire startup.
Introduces a Counter in Prometheus so that Build and Pipeline Leads can be alerted when there is even one failure to recover a job during startup.

- [X] Includes a change file
- [N/A] Updates developer documentation

