### PR TITLE
GP-3508 Expose the workflow (version) (hash) ID in the API

### DIFF
--- a/changes/add_workflow_id_to_api_endpoint.md
+++ b/changes/add_workflow_id_to_api_endpoint.md
@@ -1,0 +1,1 @@
+Add workflow ID to GET `/api/workflow/{name}/{version}` API endpoint. This can be used for deleting workflow runs by `vidarr-workflow-id`.

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
@@ -1616,6 +1616,7 @@ public final class Main implements ServerConfig {
     return DSL.jsonObject(
         literalJsonEntry("name", WORKFLOW_VERSION.NAME),
         literalJsonEntry("version", WORKFLOW_VERSION.VERSION),
+        literalJsonEntry("id", WORKFLOW_VERSION.HASH_ID),
         literalJsonEntry("metadata", WORKFLOW_VERSION.METADATA),
         literalJsonEntry("parameters", WORKFLOW_VERSION.PARAMETERS),
         literalJsonEntry(
@@ -1633,6 +1634,7 @@ public final class Main implements ServerConfig {
     return DSL.jsonObject(
         literalJsonEntry("name", WORKFLOW_VERSION.NAME),
         literalJsonEntry("version", WORKFLOW_VERSION.VERSION),
+        literalJsonEntry("id", WORKFLOW_VERSION.HASH_ID),
         literalJsonEntry("metadata", WORKFLOW_VERSION.METADATA),
         literalJsonEntry("parameters", WORKFLOW_VERSION.PARAMETERS),
         literalJsonEntry(

--- a/vidarr-server/src/test/java/ca/on/oicr/gsi/vidarr/server/MainIntegrationTest.java
+++ b/vidarr-server/src/test/java/ca/on/oicr/gsi/vidarr/server/MainIntegrationTest.java
@@ -441,6 +441,7 @@ public class MainIntegrationTest {
         .body(
             containsString("name"),
             containsString("version"),
+            containsString("id"),
             containsString("outputs"),
             containsString("language"),
             not(containsString("workflow")));
@@ -456,6 +457,7 @@ public class MainIntegrationTest {
         .body(
             containsString("name"),
             containsString("version"),
+            containsString("id"),
             containsString("outputs"),
             containsString("language"),
             containsString("workflow"),


### PR DESCRIPTION
Deleting all workflow runs for a "bad" workflow version can be done using the unload filter "vidarr-workflow-id" (which is actually the workflow version's hash ID, but users don't need to know that). Expose the "vidarr-workflow-id" in the GET `/api/workflow/{name}/{version}` endpoint.

Jira ticket:

- [x] Includes a change file
 
`N/A` Updates developer documentation

