### PR TITLE
[GP-3473] Track bad recovery IDs in memory so the Gauge can go down

### DIFF
--- a/changes/add_recovery_failures_endpoint.md
+++ b/changes/add_recovery_failures_endpoint.md
@@ -1,0 +1,1 @@
+Adds recovery-failures API endpoint which returns workflow run ids of any runs which failed to recover from the database on restart.

--- a/changes/change_recovery_exception_handling.md
+++ b/changes/change_recovery_exception_handling.md
@@ -1,0 +1,1 @@
+Wraps a significant chunk of DatabaseBackedProcessor.recover() in try-catch Exception block. This changes the error handling of SQLException on startup for now. Intend to fix this in a later release.

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
@@ -50,7 +50,7 @@ public abstract class DatabaseBackedProcessor
     extends BaseProcessor<DatabaseWorkflow, DatabaseOperation, DSLContext> {
 
   private static class BadRecoveryTracker {
-    private static final Set badRecoveryIds = new HashSet<String>();
+    private static final Set<String> badRecoveryIds = new HashSet<>();
     private static final Gauge badRecoveryCount =
         Gauge.build(
                 "vidarr_db_processor_recovery_current_failures",
@@ -775,6 +775,10 @@ public abstract class DatabaseBackedProcessor
               });
       connection.commit();
     }
+  }
+
+  protected final Set<String> recoveryFailures() {
+    return BadRecoveryTracker.badRecoveryIds;
   }
 
   protected final Optional<FileMetadata> resolveInDatabase(String inputId) {

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.zaxxer.hikari.HikariDataSource;
-import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
 import java.io.IOError;
 import java.lang.ref.SoftReference;
 import java.nio.charset.StandardCharsets;
@@ -48,11 +48,24 @@ import org.jooq.impl.DSL;
 public abstract class DatabaseBackedProcessor
     extends BaseProcessor<DatabaseWorkflow, DatabaseOperation, DSLContext> {
 
-  private static final Counter badRecoveryCount =
-      Counter.build(
-              "vidarr_db_processor_recovery_failure_count",
-              "The number of failures in recovering database-backed operations")
-          .register();
+  private static class BadRecoveryTracker {
+    private static final Set badRecoveryIds = new HashSet<String>();
+    private static final Gauge badRecoveryCount =
+        Gauge.build(
+                "vidarr_db_processor_recovery_failure_count",
+                "The number of failures in recovering database-backed operations")
+            .register();
+
+    public static void add(String id) {
+      badRecoveryIds.add(id);
+      badRecoveryCount.set(badRecoveryIds.size());
+    }
+
+    public static void remove(String id) {
+      badRecoveryIds.remove(id); // does nothing if id is not in HashSet
+      badRecoveryCount.set(badRecoveryIds.size()); // no change if remove did nothing
+    }
+  }
 
   public interface DeleteResultHandler<T> {
 
@@ -406,6 +419,7 @@ public abstract class DatabaseBackedProcessor
                                 .delete(WORKFLOW_RUN)
                                 .where(WORKFLOW_RUN.ID.eq(id_and_dead.component1()))
                                 .execute();
+                            BadRecoveryTracker.remove(workflowRunId);
                             return handler.deleted();
                           } else {
                             return handler.stillActive();
@@ -741,11 +755,11 @@ public abstract class DatabaseBackedProcessor
                                               activeOperations);
                                         }
                                       } catch (Exception e) {
+                                        String erroneousHash = record.get(WORKFLOW_RUN.HASH_ID);
                                         System.err.printf(
-                                            "Error recovering workflow run %s: \n",
-                                            record.get(WORKFLOW_RUN.HASH_ID));
+                                            "Error recovering workflow run %s: \n", erroneousHash);
                                         e.printStackTrace();
-                                        badRecoveryCount.inc();
+                                        BadRecoveryTracker.add(erroneousHash);
                                         System.err.println(
                                             "Continuing recovery on next record in database if one exists.");
                                       }


### PR DESCRIPTION
Jira ticket: GP-3473

This change has big implications!
Since the vidarr server always has a DatabaseBackedProcessor, then it will always have a BadRecoveryTracker.
This opens the possibility for an API endpoint that returns the 'outstanding' failures.
And at that point, why not just wire everything together and automate the deletion of the failures? Will there ever be a time when we want to do something else?

- [x] Includes a change file
- [ ] Updates developer documentation

