### PR TITLE
GP-3473 add recovery-failures endpoint to swagger

### DIFF
--- a/vidarr-server/src/main/resources/ca/on/oicr/gsi/vidarr/server/api-docs/vidarr.json
+++ b/vidarr-server/src/main/resources/ca/on/oicr/gsi/vidarr/server/api-docs/vidarr.json
@@ -1548,7 +1548,17 @@
         "description": "Get the list of recovery failures from the most recent boot of Vidarr that have not yet been deleted, i.e. outstanding failures.",
         "responses": {
           "200": {
-            "description": "List of outstanding recovery failures."
+            "description": "List of outstanding recovery failures.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
 	  }
         }
       }

--- a/vidarr-server/src/main/resources/ca/on/oicr/gsi/vidarr/server/api-docs/vidarr.json
+++ b/vidarr-server/src/main/resources/ca/on/oicr/gsi/vidarr/server/api-docs/vidarr.json
@@ -1546,6 +1546,7 @@
       "get": {
         "summary": "Get boot recovery failures",
         "description": "Get the list of recovery failures from the most recent boot of Vidarr that have not yet been deleted, i.e. outstanding failures.",
+        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "List of outstanding recovery failures."

--- a/vidarr-server/src/main/resources/ca/on/oicr/gsi/vidarr/server/api-docs/vidarr.json
+++ b/vidarr-server/src/main/resources/ca/on/oicr/gsi/vidarr/server/api-docs/vidarr.json
@@ -1546,7 +1546,6 @@
       "get": {
         "summary": "Get boot recovery failures",
         "description": "Get the list of recovery failures from the most recent boot of Vidarr that have not yet been deleted, i.e. outstanding failures.",
-        "produces": ["application/json"],
         "responses": {
           "200": {
             "description": "List of outstanding recovery failures."

--- a/vidarr-server/src/main/resources/ca/on/oicr/gsi/vidarr/server/api-docs/vidarr.json
+++ b/vidarr-server/src/main/resources/ca/on/oicr/gsi/vidarr/server/api-docs/vidarr.json
@@ -1542,6 +1542,17 @@
         "summary": "Update external versions"
       }
     },
+    "/api/recovery-failures": {
+      "get": {
+        "summary": "Get boot recovery failures",
+        "description": "Get the list of recovery failures from the most recent boot of Vidarr that have not yet been deleted, i.e. outstanding failures.",
+        "responses": {
+          "200": {
+            "description": "List of outstanding recovery failures."
+	  }
+        }
+      }
+    },
     "/api/workflow/{name}": {
       "delete": {
         "description": "Deactivate a workflow. This does not stop inflight actions from using this workflow. It merely stops it from being available in the workflow catalogue.",


### PR DESCRIPTION
Can anyone identify why this swagger config file won't compile?
I'm following the specification at https://swagger.io/docs/specification/2-0/basic-structure/
but when I run vidarr with this change it says "Parser error on line 1918
unexpected end of the stream within a flow collection, The provided definition does not specify a valid version field." even though the 'openapi' line is definitely still there.
Can't tell what I'm doing wrong.

Jira ticket: GP-3473

- [ ] Includes a change file
- [ ] Updates developer documentation

