### PR TITLE
Update OpenAPI documentation

### DIFF
--- a/vidarr-server/src/main/resources/ca/on/oicr/gsi/vidarr/server/api-docs/vidarr.json
+++ b/vidarr-server/src/main/resources/ca/on/oicr/gsi/vidarr/server/api-docs/vidarr.json
@@ -1077,6 +1077,8 @@
                 "$ref": "#/components/schemas/CopyUnloadRequest"
               }
             }
+          },
+          "description": "Available filters are: [\"and\", \"not\", \"or\", \"vidarr-analysis-id\", \"vidarr-completed-after\", \"vidarr-external-id\", \"vidarr-external-provider\", \"vidarr-last-submitted-after\", \"vidarr-workflow-id\", \"vidarr-workflow-name\", \"vidarr-workflow-run-id\"]. Filters can be combined."
           }
         },
         "responses": {


### PR DESCRIPTION
As mentioned in #245, Swagger is unable to generate the definition/schema on its own, so I'm re-adding this to make it easier for our users.

`N/A` Includes a change file
`N/A` Updates developer documentation

