### PR TITLE
Revert flyway-core version to fix deploy issue

### DIFF
--- a/changes/fix_flyway-core-deploy-version.md
+++ b/changes/fix_flyway-core-deploy-version.md
@@ -1,0 +1,1 @@
+issue with deploying updated verison of flyway-core by reverting it to known good version

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
       <dependency>
         <groupId>org.flywaydb</groupId>
         <artifactId>flyway-core</artifactId>
-        <version>9.19.4</version>
+        <version>9.16.3</version>
       </dependency>
       <dependency>
         <groupId>com.zaxxer</groupId>


### PR DESCRIPTION
I'm having an issue deploying Vidarr with flyway-core v9.19.4:
```
Exception in thread "main" java.util.ServiceConfigurationError: org.flywaydb.core.extensibility.Plugin: org.flywaydb.core.internal.reports.json.InfoResultDeserializer Unable to get public no-arg constructor
  at java.base/java.util.ServiceLoader.fail(ServiceLoader.java:586)
  at java.base/java.util.ServiceLoader.getConstructor(ServiceLoader.java:679)
  at java.base/java.util.ServiceLoader.loadProvider(ServiceLoader.java:906)
  at java.base/java.util.ServiceLoader$ModuleServicesLookupIterator.hasNext(ServiceLoader.java:1084)
  at java.base/java.util.ServiceLoader$2.hasNext(ServiceLoader.java:1309)
  at java.base/java.util.ServiceLoader$3.hasNext(ServiceLoader.java:1393)
  at org.flywaydb.core@9.19.4/org.flywaydb.core.internal.plugin.PluginRegister.registerPlugins(PluginRegis>
  at org.flywaydb.core@9.19.4/org.flywaydb.core.internal.plugin.PluginRegister.getPlugins(PluginRegister.j>
  at org.flywaydb.core@9.19.4/org.flywaydb.core.internal.plugin.PluginRegister.getPlugins(PluginRegister.j>
  at org.flywaydb.core@9.19.4/org.flywaydb.core.api.configuration.ClassicConfiguration.configureFromConfig>
  at org.flywaydb.core@9.19.4/org.flywaydb.core.api.configuration.ClassicConfiguration.configure(ClassicCo>
  at org.flywaydb.core@9.19.4/org.flywaydb.core.api.configuration.ClassicConfiguration.<init>(ClassicConfi>
  at org.flywaydb.core@9.19.4/org.flywaydb.core.Flyway.<init>(Flyway.java:112)
  at org.flywaydb.core@9.19.4/org.flywaydb.core.api.configuration.FluentConfiguration.load(FluentConfigura>
  at ca.on.oicr.gsi.vidarr.server@0.13.1-SNAPSHOT/ca.on.oicr.gsi.vidarr.server.Main.<init>(Main.java:661)
  at ca.on.oicr.gsi.vidarr.server@0.13.1-SNAPSHOT/ca.on.oicr.gsi.vidarr.server.Main.main(Main.java:359)
 by: java.lang.NoClassDefFoundError: com/google/gson/JsonElement
  at java.base/java.lang.Class.getDeclaredConstructors0(Native Method)
  at java.base/java.lang.Class.privateGetDeclaredConstructors(Class.java:3373)
  at java.base/java.lang.Class.getConstructor0(Class.java:3578)
  at java.base/java.lang.Class.getConstructor(Class.java:2271)
  at java.base/java.util.ServiceLoader$1.run(ServiceLoader.java:666)
  at java.base/java.util.ServiceLoader$1.run(ServiceLoader.java:663)
  at java.base/java.security.AccessController.doPrivileged(AccessController.java:569)
  at java.base/java.util.ServiceLoader.getConstructor(ServiceLoader.java:674)
  ... 14 more
 by: java.lang.ClassNotFoundException: com.google.gson.JsonElement
  at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
  at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
  at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520)
  ... 22 more

```
This is related related to [this Flyway GH issue](https://github.com/flyway/flyway/issues/3672) but v9.19+ is not resolving it for me, so I'm reverting. (Weird that CI passes though, so it's possible that it's a configuration issue on my end, would appreciate if anyone else could reproduce...)