### PR TITLE
[GP-4003] Write empty object if null accessory files

### DIFF
--- a/changes/fix_unload-null-accessories.md
+++ b/changes/fix_unload-null-accessories.md
@@ -1,0 +1,3 @@
+Copy-out & unload correctly format empty accessoryFiles as `{}` rather than
+null, allowing load to accept the output
+

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
@@ -1241,20 +1241,22 @@ public final class Main implements ServerConfig {
             DSL.jsonObject(
                 literalJsonEntry(
                     "accessoryFiles",
-                    DSL.field(
-                        DSL.select(
-                                DSL.jsonObjectAgg(
-                                    WORKFLOW_VERSION_ACCESSORY.FILENAME,
-                                    accessoryDefinition.WORKFLOW_FILE))
-                            .from(
-                                WORKFLOW_VERSION_ACCESSORY
-                                    .join(accessoryDefinition)
-                                    .on(
-                                        accessoryDefinition.ID.eq(
-                                            WORKFLOW_VERSION_ACCESSORY.WORKFLOW_DEFINITION))
-                                    .where(
-                                        WORKFLOW_VERSION_ACCESSORY.WORKFLOW_VERSION.eq(
-                                            WORKFLOW_VERSION.ID))))),
+                    DSL.coalesce(
+                        DSL.field(
+                            DSL.select(
+                                    DSL.jsonObjectAgg(
+                                        WORKFLOW_VERSION_ACCESSORY.FILENAME,
+                                        accessoryDefinition.WORKFLOW_FILE))
+                                .from(
+                                    WORKFLOW_VERSION_ACCESSORY
+                                        .join(accessoryDefinition)
+                                        .on(
+                                            accessoryDefinition.ID.eq(
+                                                WORKFLOW_VERSION_ACCESSORY.WORKFLOW_DEFINITION))
+                                        .where(
+                                            WORKFLOW_VERSION_ACCESSORY.WORKFLOW_VERSION.eq(
+                                                WORKFLOW_VERSION.ID)))),
+                            JSON.json("{}"))),
                 literalJsonEntry("language", WORKFLOW_DEFINITION.WORKFLOW_LANGUAGE),
                 literalJsonEntry("name", WORKFLOW_VERSION.NAME),
                 literalJsonEntry("outputs", WORKFLOW_VERSION.METADATA),


### PR DESCRIPTION
Brings dumpUnloadDataToJson() into line with how workflowVersionWithDefinitionFields() works. 
Allows /load to immediately accept /copy-out and /unload 's output without modification

Jira ticket: GP-4003

- [X] Includes a change file
- [N/A] Updates developer documentation

