### PR TITLE
Allow full workflow run ID hash in vidarr-workflow-run-id unload filter

### DIFF
--- a/changes/add_parsing_full_wfr_ids.md
+++ b/changes/add_parsing_full_wfr_ids.md
@@ -1,0 +1,1 @@
+Parsing for full Vidarr workflow run IDs in the vidarr-workflow-run-id unload filter

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
@@ -1310,4 +1310,12 @@ public abstract class DatabaseBackedProcessor
           String.format("'%s' is a malformed Vidarr file identifier", id));
     return matcher.group("hash");
   }
+
+  public static String extractHashIfIsFullWorkflowRunId(String id) {
+    Matcher matcher = BaseProcessor.WORKFLOW_RUN_ID.matcher(id);
+    if (!matcher.matches())
+      // assume it's already a hash
+      return id;
+    return matcher.group("hash");
+  }
 }

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
@@ -2589,7 +2589,9 @@ public final class Main implements ServerConfig {
                                                   @Override
                                                   public Condition workflowRunId(
                                                       Stream<String> ids) {
-                                                    return match(WORKFLOW_RUN.HASH_ID, ids);
+                                                    var hashIds =
+                                                        ids.map(id -> processor.extractHashIfIsFullWorkflowRunId(id));
+                                                    return match(WORKFLOW_RUN.HASH_ID, hashIds);
                                                   }
                                                 })))
                             .fetch(WORKFLOW_RUN.ID));


### PR DESCRIPTION
Jira ticket: GP-4018

- [x] Includes a change file
- [ ] Updates developer documentation - N/A

This is a convenience method for doing things like "take a list of vidarr workflow run IDs for archiving, query the copy-out endpoint for this list, and do something with the resulting output file" and will make future me's life easier.

