### PR TITLE
Correct floating point type checking

### DIFF
--- a/changes/fix_floating_point.md
+++ b/changes/fix_floating_point.md
@@ -1,0 +1,1 @@
+Correct type checking of floating point JSON values

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/CheckInputType.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/CheckInputType.java
@@ -172,7 +172,7 @@ public final class CheckInputType implements InputType.Visitor<Stream<String>> {
 
   @Override
   public Stream<String> floating() {
-    return input.isFloatingPointNumber()
+    return input.isNumber()
         ? Stream.empty()
         : Stream.of(
             String.format("%s: Expected float but got %s.", context, input.toPrettyString()));

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/ValidateJsonToSimpleType.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/ValidateJsonToSimpleType.java
@@ -74,7 +74,7 @@ public final class ValidateJsonToSimpleType implements BasicType.Visitor<Stream<
 
   @Override
   public Stream<String> floating() {
-    return input.isFloatingPointNumber()
+    return input.isNumber()
         ? Stream.empty()
         : Stream.of(
             String.format("%s: Expected float but got %s.", context, input.toPrettyString()));


### PR DESCRIPTION
The code mistakenly uses `isFloatingPointNumber`, which requires a number with a decimal point, but this is not required by JSON to indicate a floating point number. This allows integral numbers to be used in floating point contexts.

Jira ticket:

- [X] Includes a change file
- [ ] Updates developer documentation

