### PR TITLE
Accept hyphens in vidarr instance portion of hash identifiers

### DIFF
--- a/changes/change_accept_hashes_in_vidarr_ids.md
+++ b/changes/change_accept_hashes_in_vidarr_ids.md
@@ -1,0 +1,1 @@
+Accept hashes in vidarr instance name portion of Vidarr hash IDs

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseProcessor.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseProcessor.java
@@ -766,13 +766,13 @@ public abstract class BaseProcessor<
 
   public static final Pattern ANALYSIS_RECORD_ID =
       Pattern.compile(
-          "vidarr:(?<instance>[a-z][a-z0-9_]*|_)/(?:workflow/(?<name>[a-z][a-zA-Z0-9_]*)/(?<version>[0-9]+(?:\\.[0-9]+)*(?:-[0-9]+)?)/(?<workflowhash>[0-9a-fA-F]+)/run/)?(?<type>file|url)/(?<hash>[0-9a-fA-F]+)");
+          "vidarr:(?<instance>[a-z][a-z0-9_-]*|_)/(?:workflow/(?<name>[a-z][a-zA-Z0-9_]*)/(?<version>[0-9]+(?:\\.[0-9]+)*(?:-[0-9]+)?)/(?<workflowhash>[0-9a-fA-F]+)/run/)?(?<type>file|url)/(?<hash>[0-9a-fA-F]+)");
   public static final Pattern WORKFLOW_RECORD_ID =
       Pattern.compile(
-          "vidarr:(?<instance>[a-z][a-z0-9_]*|_)/workflow/(?<name>[a-z][a-zA-Z0-9_]*)?/(?<version>[0-9]+(?:\\.[0-9]+)*(?:-[0-9]+)?)");
+          "vidarr:(?<instance>[a-z][a-z0-9_-]*|_)/workflow/(?<name>[a-z][a-zA-Z0-9_]*)?/(?<version>[0-9]+(?:\\.[0-9]+)*(?:-[0-9]+)?)");
   public static final Pattern WORKFLOW_RUN_ID =
       Pattern.compile(
-          "vidarr:(?<instance>[a-z][a-z0-9_]*|_)/(?:workflow/(?<name>[a-z][a-zA-Z0-9_]*)/(?<version>[0-9]+(?:\\.[0-9]+)*(?:-[0-9]+)?)/)?run/(?<hash>[0-9a-fA-F]+)");
+          "vidarr:(?<instance>[a-z][a-z0-9_-]*|_)/(?:workflow/(?<name>[a-z][a-zA-Z0-9_]*)/(?<version>[0-9]+(?:\\.[0-9]+)*(?:-[0-9]+)?)/)?run/(?<hash>[0-9a-fA-F]+)");
 
   public static Stream<String> extractInputVidarrIds(
       ObjectMapper mapper, WorkflowDefinition definition, JsonNode arguments) {


### PR DESCRIPTION
Jira ticket: GP-4093

- [x] Includes a change file
- [ ] Updates developer documentation

Right now, vidarr-archival-stage's `archival-stage` name means its metadata wouldn't be usable by other Vidarrs. I think that accepting hyphens is preferable to renaming the instance to `archival_stage` or `archivalstage` (which will be tricky to remember, especially for olive developers and pipeline leads).