### PR TITLE
Allow retrying runs failing during provision-out

### DIFF
--- a/changes/add_retry_provision_out.md
+++ b/changes/add_retry_provision_out.md
@@ -1,0 +1,1 @@
+* Allow retrying workflow runs that fail during provision-out

--- a/vidarr-cli/src/main/java/ca/on/oicr/gsi/vidarr/cli/SingleShotOperation.java
+++ b/vidarr-cli/src/main/java/ca/on/oicr/gsi/vidarr/cli/SingleShotOperation.java
@@ -3,6 +3,7 @@ package ca.on.oicr.gsi.vidarr.cli;
 import ca.on.oicr.gsi.vidarr.core.ActiveOperation;
 import ca.on.oicr.gsi.vidarr.core.OperationStatus;
 import com.fasterxml.jackson.databind.JsonNode;
+import java.lang.System.Logger.Level;
 
 final class SingleShotOperation implements ActiveOperation<Void> {
   private JsonNode state;
@@ -18,6 +19,11 @@ final class SingleShotOperation implements ActiveOperation<Void> {
   @Override
   public void debugInfo(JsonNode info, Void transaction) {
     // Throw this information away since we don't really want to log it
+  }
+
+  @Override
+  public void error(String reason, Void transaction) {
+    singleShotWorkflow.log(Level.ERROR, reason);
   }
 
   @Override

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/ActiveOperation.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/ActiveOperation.java
@@ -17,6 +17,14 @@ public interface ActiveOperation<TX> {
   void debugInfo(JsonNode info, TX transaction);
 
   /**
+   * Set the failure message
+   *
+   * @param reason the failure reason
+   * @param transaction the transaction to perform the update in
+   */
+  void error(String reason, TX transaction);
+
+  /**
    * Check if the operation is still live
    *
    * @return if false, no callbacks will be scheduled.

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/OneOfOutputProvisioner.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/OneOfOutputProvisioner.java
@@ -69,6 +69,12 @@ public final class OneOfOutputProvisioner implements OutputProvisioner {
   }
 
   @Override
+  public void retry(JsonNode state, WorkMonitor<Result, JsonNode> monitor) {
+    final var type = state.get(0).asText();
+    provisioners.get(type).retry(state.get(1), new MonitorWithType<>(monitor, type));
+  }
+
+  @Override
   public void startup() {
     for (final var provisioner : provisioners.values()) {
       provisioner.startup();

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/RecoveryType.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/RecoveryType.java
@@ -1,0 +1,35 @@
+package ca.on.oicr.gsi.vidarr.core;
+
+import ca.on.oicr.gsi.vidarr.OutputProvisioner;
+import ca.on.oicr.gsi.vidarr.OutputProvisioner.Result;
+import ca.on.oicr.gsi.vidarr.RuntimeProvisioner;
+import ca.on.oicr.gsi.vidarr.core.WrappedMonitor.RecoveryStarter;
+
+public enum RecoveryType {
+  RECOVER {
+    @Override
+    RecoveryStarter<Result> provisionOut(OutputProvisioner provisioner) {
+      return provisioner::recover;
+    }
+
+    @Override
+    RecoveryStarter<Result> runtime(RuntimeProvisioner provisioner) {
+      return provisioner::recover;
+    }
+  },
+  RETRY {
+    @Override
+    RecoveryStarter<Result> provisionOut(OutputProvisioner provisioner) {
+      return provisioner::retry;
+    }
+
+    @Override
+    RecoveryStarter<Result> runtime(RuntimeProvisioner provisioner) {
+      return provisioner::retry;
+    }
+  };
+
+  abstract RecoveryStarter<Result> provisionOut(OutputProvisioner outputProvisioner);
+
+  abstract RecoveryStarter<Result> runtime(RuntimeProvisioner provisioner);
+}

--- a/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/CromwellOutputProvisioner.java
+++ b/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/CromwellOutputProvisioner.java
@@ -92,7 +92,9 @@ public class CromwellOutputProvisioner
       CLIENT
           .sendAsync(
               HttpRequest.newBuilder()
-                  .uri(CromwellMetadataURL.formatMetadataURL(cromwellUrl, state.getCromwellId(), debugCalls))
+                  .uri(
+                      CromwellMetadataURL.formatMetadataURL(
+                          cromwellUrl, state.getCromwellId(), debugCalls))
                   .timeout(Duration.ofMinutes(1))
                   .GET()
                   .build(),
@@ -113,13 +115,14 @@ public class CromwellOutputProvisioner
                     // so we can have call info for debugging.
                   case "Aborted":
                   case "Failed":
-                    if (debugCalls){
+                    if (debugCalls) {
                       monitor.log(
-                              System.Logger.Level.INFO,
-                              String.format("Cromwell job %s is failed. Cromwell OutputProvisioner "
+                          System.Logger.Level.INFO,
+                          String.format(
+                              "Cromwell job %s is failed. Cromwell OutputProvisioner "
                                   + "is configured to have already fetched calls info. Skipping "
-                                  + "second request.", state.getCromwellId())
-                      );
+                                  + "second request.",
+                              state.getCromwellId()));
                       monitor.permanentFailure("Cromwell failure: " + result.getStatus());
                       break;
                     }
@@ -133,7 +136,9 @@ public class CromwellOutputProvisioner
                     CLIENT
                         .sendAsync(
                             HttpRequest.newBuilder()
-                                .uri(CromwellMetadataURL.formatMetadataURL(cromwellUrl, state.getCromwellId(), true))
+                                .uri(
+                                    CromwellMetadataURL.formatMetadataURL(
+                                        cromwellUrl, state.getCromwellId(), true))
                                 .timeout(Duration.ofMinutes(1))
                                 .GET()
                                 .build(),
@@ -160,7 +165,8 @@ public class CromwellOutputProvisioner
                                       state.getCromwellId(), cromwellUrl, t2.getMessage()));
                               CROMWELL_FAILURES.labels(cromwellUrl).inc();
 
-                              // TODO: this may schedule 2 requests to cromwell /metadata now. Consider
+                              // TODO: this may schedule 2 requests to cromwell /metadata now.
+                              // Consider
                               // a failure-unique check
                               monitor.scheduleTask(
                                   CHECK_DELAY, TimeUnit.MINUTES, () -> check(state, monitor));
@@ -445,6 +451,12 @@ public class CromwellOutputProvisioner
     } else {
       check(state, monitor);
     }
+  }
+
+  @Override
+  protected void retry(ProvisionState state, WorkMonitor<Result, ProvisionState> monitor) {
+    state.setCromwellId(null);
+    recover(state, monitor);
   }
 
   public void setChunks(int[] chunks) {

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/BaseJsonOutputProvisioner.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/BaseJsonOutputProvisioner.java
@@ -153,4 +153,19 @@ public abstract class BaseJsonOutputProvisioner<M, S, F> implements OutputProvis
       monitor.permanentFailure(e.toString());
     }
   }
+  /**
+   * Restart a failed provisioning process from state saved in the database
+   *
+   * @see #retry(JsonNode, WorkMonitor)
+   */
+  protected abstract void retry(S state, WorkMonitor<Result, S> monitor);
+
+  @Override
+  public final void retry(JsonNode state, WorkMonitor<Result, JsonNode> monitor) {
+    try {
+      retry(mapper.treeToValue(state, stateClass), new JsonWorkMonitor<>(monitor));
+    } catch (Exception e) {
+      monitor.permanentFailure(e.toString());
+    }
+  }
 }

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/BaseJsonRuntimeProvisioner.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/BaseJsonRuntimeProvisioner.java
@@ -106,4 +106,20 @@ public abstract class BaseJsonRuntimeProvisioner<S> implements RuntimeProvisione
       monitor.permanentFailure(e.toString());
     }
   }
+
+  /**
+   * Restart a failed provisioning process from state saved in the database
+   *
+   * @see #recover(JsonNode, WorkMonitor)
+   */
+  protected abstract void retry(S state, WorkMonitor<OutputProvisioner.Result, S> monitor);
+
+  @Override
+  public final void retry(JsonNode state, WorkMonitor<OutputProvisioner.Result, JsonNode> monitor) {
+    try {
+      retry(mapper.treeToValue(state, stateClass), new JsonWorkMonitor<>(monitor));
+    } catch (Exception e) {
+      monitor.permanentFailure(e.toString());
+    }
+  }
 }

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/OutputProvisioner.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/OutputProvisioner.java
@@ -185,6 +185,21 @@ public interface OutputProvisioner {
   void recover(JsonNode state, WorkMonitor<Result, JsonNode> monitor);
 
   /**
+   * Restart a provisioning process from state saved in the database from a failed task.
+   *
+   * <p>This method should not do any externally-visible work. Anything it needs should be done in a
+   * {@link WorkMonitor#scheduleTask(Runnable)} callback so that Vidarr can execute it once the
+   * database is in a healthy state.
+   *
+   * <p>This is meant to allow retrying the provision out process after a failure such as out of
+   * disk that doesn't require reprocessing the data.
+   *
+   * @param state the frozen database state
+   * @param monitor the monitor structure for writing the output of the provisioning process
+   */
+  void retry(JsonNode state, WorkMonitor<Result, JsonNode> monitor);
+
+  /**
    * Called to initialise this output provisioner.
    *
    * <p>If the configuration is invalid, this should throw a runtime exception.

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/RuntimeProvisioner.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/RuntimeProvisioner.java
@@ -101,6 +101,18 @@ public interface RuntimeProvisioner {
   void recover(JsonNode state, WorkMonitor<OutputProvisioner.Result, JsonNode> monitor);
 
   /**
+   * Restart a provisioning process from state saved in the database that previously failed
+   *
+   * <p>Rebuild state from `state` object then schedule appropriate next step with
+   * `monitor.scheduleTask()`. This is meant to allow retrying the provision out process after a
+   * failure such as out of disk that doesn't require reprocessing the data.
+   *
+   * @param state the frozen database state
+   * @param monitor the monitor structure for writing the output of the provisioning process
+   */
+  void retry(JsonNode state, WorkMonitor<OutputProvisioner.Result, JsonNode> monitor);
+
+  /**
    * Called to initialise this runtime provisioner.
    *
    * <p>Actual reading of configuration files does not need to be done, due to jackson-databind

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/RetryProvisionOutRequest.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/RetryProvisionOutRequest.java
@@ -1,0 +1,17 @@
+package ca.on.oicr.gsi.vidarr.api;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class RetryProvisionOutRequest {
+  private List<String> workflowRunIds;
+
+  public List<String> getWorkflowRunIds() {
+    return workflowRunIds;
+  }
+
+  public void setWorkflowRunIds(List<String> workflowRunIds) {
+    this.workflowRunIds = workflowRunIds;
+  }
+}

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadRequest.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadRequest.java
@@ -4,7 +4,7 @@ import ca.on.oicr.gsi.vidarr.UnloadFilter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class UnloadRequest {
+public final class UnloadRequest {
   private UnloadFilter filter;
   private boolean recursive;
 

--- a/vidarr-server/pom.xml
+++ b/vidarr-server/pom.xml
@@ -121,7 +121,7 @@
             <removeVolumes>true</removeVolumes>
             <images>
               <image>
-                <name>postgres:12-alpine</name>
+                <name>postgres:15-alpine</name>
                 <alias>postgres</alias>
                 <run>
                   <env>
@@ -215,8 +215,8 @@
                         <from>i -&gt; Phase.values()[i]</from>
                         <to>Phase::ordinal</to>
                       </lambdaConverter>
-                      <expression>.*\.engine_phase</expression>
-                      <types>.*</types>
+                      <includeExpression>.*\.engine_phase</includeExpression>
+                      <includeTypes>.*</includeTypes>
                     </forcedType>
                     <forcedType>
                       <userType>ca.on.oicr.gsi.vidarr.core.OperationStatus</userType>
@@ -224,8 +224,8 @@
                         <from>OperationStatus::valueOf</from>
                         <to>OperationStatus::name</to>
                       </lambdaConverter>
-                      <expression>public\.active_operation\.status</expression>
-                      <types>.*</types>
+                      <includeExpression>public\.active_operation\.status</includeExpression>
+                      <includeTypes>.*</includeTypes>
                     </forcedType>
                     <forcedType>
                       <userType>ca.on.oicr.gsi.vidarr.WorkflowLanguage</userType>
@@ -233,8 +233,8 @@
                         <from>WorkflowLanguage::valueOf</from>
                         <to>WorkflowLanguage::name</to>
                       </lambdaConverter>
-                      <expression>public\.workflow_definition\.workflow_language</expression>
-                      <types>.*</types>
+                      <includeExpression>public\.workflow_definition\.workflow_language</includeExpression>
+                      <includeTypes>.*</includeTypes>
                     </forcedType>
                     <forcedType>
                       <userType>com.fasterxml.jackson.databind.JsonNode</userType>
@@ -242,7 +242,7 @@
                       <includeExpression>.*</includeExpression>
                       <!-- We leave labels alone so we can manipulate them using the database functions -->
                       <excludeExpression>.*\.labels</excludeExpression>
-                      <types>JSONB</types>
+                      <includeTypes>JSONB</includeTypes>
                     </forcedType>
                   </forcedTypes>
                 </database>

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseOperation.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseOperation.java
@@ -81,6 +81,11 @@ public class DatabaseOperation implements ActiveOperation<DSLContext> {
   }
 
   @Override
+  public void error(String reason, DSLContext transaction) {
+    updateField(ACTIVE_OPERATION.ERROR, reason, transaction);
+  }
+
+  @Override
   public boolean isLive() {
     return liveness.get();
   }

--- a/vidarr-server/src/main/resources/ca/on/oicr/gsi/vidarr/server/api-docs/vidarr.json
+++ b/vidarr-server/src/main/resources/ca/on/oicr/gsi/vidarr/server/api-docs/vidarr.json
@@ -1004,6 +1004,9 @@
           "enginePhase": {
             "type": "integer"
           },
+          "error": {
+            "type": "string"
+          },
           "id": {
             "type": "string"
           },
@@ -1071,14 +1074,14 @@
       "post": {
         "description": "Get the workflow, workflow version, and workflow run data for the items selected by the filter. If 'recursive' is true, the output will also include any workflow runs that consumed the output of a workflow run selected by the filter.",
         "requestBody": {
-          "description": "Available filters are: [\"and\", \"not\", \"or\", \"vidarr-analysis-id\", \"vidarr-completed-after\", \"vidarr-external-id\", \"vidarr-external-provider\", \"vidarr-last-submitted-after\", \"vidarr-workflow-id\", \"vidarr-workflow-name\", \"vidarr-workflow-run-id\"]. Filters can be combined.",
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/CopyUnloadRequest"
               }
             }
-          }
+          },
+          "description": "Available filters are: [\"and\", \"not\", \"or\", \"vidarr-analysis-id\", \"vidarr-completed-after\", \"vidarr-external-id\", \"vidarr-external-provider\", \"vidarr-last-submitted-after\", \"vidarr-workflow-id\", \"vidarr-workflow-name\", \"vidarr-workflow-run-id\"]. Filters can be combined."
         },
         "responses": {
           "200": {
@@ -1311,6 +1314,47 @@
           }
         },
         "summary": "Get boot recovery failures"
+      }
+    },
+    "/api/retry-provision-out": {
+      "post": {
+        "description": "Retries failed workflow that are stuck in the provision-out stage. The workflow run identifiers can be supplied or null can be used to restart all workflow runs.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "workflowRunIds": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "The workflow runs that were queued for retry."
+          }
+        },
+        "summary": "Retries failed provisioning out",
+        "tags": [
+          "workflow-run"
+        ]
       }
     },
     "/api/run/{hash}": {

--- a/vidarr-server/src/main/resources/db/migration/V0018__error.sql
+++ b/vidarr-server/src/main/resources/db/migration/V0018__error.sql
@@ -1,0 +1,1 @@
+ALTER TABLE active_operation ADD COLUMN error text;


### PR DESCRIPTION
Provides a new API and endpoint to allow retrying workflow runs that failed during the provision-out stage by forcibly restarting the provision-out operations that failed.

- [X] Includes a change file
- [X] Updates developer documentation

