### PR TITLE
[GP-3618] - Improved logging of required config file properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 For unreleased changes, see [changes](changes).
 
 -----------------------------------------------------------------------------
+
 ## [0.17.2] - 2023-10-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 For unreleased changes, see [changes](changes).
 
 -----------------------------------------------------------------------------
-## [0.17.3] - 2024-02-02
-
-### Fixed
-
-* Improved logging of required config file properties
-
 ## [0.17.2] - 2023-10-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0).
 For unreleased changes, see [changes](changes).
 
 -----------------------------------------------------------------------------
+## [0.17.3] - 2024-02-02
+
+### Fixed
+
+* Improved logging of required config file properties
 
 ## [0.17.2] - 2023-10-25
 

--- a/changes/fix_config_properties_error_logging.md
+++ b/changes/fix_config_properties_error_logging.md
@@ -1,0 +1,2 @@
+Fix vidarr logging
+* Improved logging of required config file properties

--- a/vidarr-cli/src/main/java/ca/on/oicr/gsi/vidarr/cli/TargetConfiguration.java
+++ b/vidarr-cli/src/main/java/ca/on/oicr/gsi/vidarr/cli/TargetConfiguration.java
@@ -3,8 +3,12 @@ package ca.on.oicr.gsi.vidarr.cli;
 import ca.on.oicr.gsi.Pair;
 import ca.on.oicr.gsi.vidarr.*;
 import ca.on.oicr.gsi.vidarr.core.Target;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -14,6 +18,17 @@ public final class TargetConfiguration {
   private List<InputProvisioner> inputs;
   private List<OutputProvisioner> outputs;
   private List<RuntimeProvisioner> runtimes;
+
+  @JsonCreator
+  public TargetConfiguration(@JsonProperty("engine") WorkflowEngine engine,
+                             @JsonProperty("inputs") List<InputProvisioner> inputs,
+                             @JsonProperty("outputs") List<OutputProvisioner> outputs,
+                             @JsonProperty("runtimes") List<RuntimeProvisioner> runtimes) {
+    this.engine = Objects.requireNonNull(engine, "Engine must not be null");
+    this.inputs = Objects.requireNonNull(inputs, "Inputs must not be null");
+    this.outputs = Objects.requireNonNull(outputs, "Outputs must not be null");
+    this.runtimes = Objects.requireNonNull(runtimes, "Runtimes must not be null");
+  }
 
   public WorkflowEngine getEngine() {
     return engine;

--- a/vidarr-cli/src/main/java/ca/on/oicr/gsi/vidarr/cli/TargetConfiguration.java
+++ b/vidarr-cli/src/main/java/ca/on/oicr/gsi/vidarr/cli/TargetConfiguration.java
@@ -24,10 +24,10 @@ public final class TargetConfiguration {
                              @JsonProperty("inputs") List<InputProvisioner> inputs,
                              @JsonProperty("outputs") List<OutputProvisioner> outputs,
                              @JsonProperty("runtimes") List<RuntimeProvisioner> runtimes) {
-    this.engine = Objects.requireNonNull(engine, "Engine must not be null");
-    this.inputs = Objects.requireNonNull(inputs, "Inputs must not be null");
-    this.outputs = Objects.requireNonNull(outputs, "Outputs must not be null");
-    this.runtimes = Objects.requireNonNull(runtimes, "Runtimes must not be null");
+    this.engine = Objects.requireNonNull(engine, "Engine object missing from config");
+    this.inputs = Objects.requireNonNull(inputs, "Inputs object missing from config");
+    this.outputs = Objects.requireNonNull(outputs, "Outputs object missing from config");
+    this.runtimes = Objects.requireNonNull(runtimes, "Runtimes object missing from config");
   }
 
   public WorkflowEngine getEngine() {


### PR DESCRIPTION
- The @JsonCreator annotation tells Jackson to use the constructor during deserialization.
- Each property is annotated with @JsonProperty to match the JSON keys.
- The constructor checks that none of the required properties are null, throwing an ValueInstantiationException with a descriptive error message if any of them are null.
- This ensures that the required properties (engine, inputs, outputs, and runtimes) are not null before iterating over them in the toTarget() method. 

Jira ticket: https://jira.oicr.on.ca/browse/GP-3618

   ✅ Includes a change file
   Updates developer documentation (not needed)