### PR TITLE
Create an order to check consumable resources

### DIFF
--- a/changes/add_cr_order.md
+++ b/changes/add_cr_order.md
@@ -1,0 +1,1 @@
+* Allows setting checking order on conumable resources

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/ConsumableResource.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/ConsumableResource.java
@@ -76,6 +76,19 @@ public interface ConsumableResource {
   Optional<Pair<String, BasicType>> inputFromSubmitter();
 
   /**
+   * The order in which this resource should be checked.
+   *
+   * <p>Some consumable resources might want to be checked first, especially ones that intend to
+   * track information. This causes Vidarr to check consumable resources in an order that makes
+   * sense for those resources.
+   *
+   * @return the priority; larger is earlier
+   */
+  default int priority() {
+    return 0;
+  }
+
+  /**
    * Indicate that Vidarr has restarted and it is reasserting an old claim.
    *
    * @param workflowName the name of the workflow


### PR DESCRIPTION
Since consumable resources might track information, it makes sense to check some before others. This provides a way to do that.

Jira ticket:

- [X] Includes a change file
- [X] Updates developer documentation

