### PR TITLE
Remove stamp coupling in alert cache

### DIFF
--- a/vidarr-prometheus/src/main/java/ca/on/oicr/gsi/vidarr/prometheus/AlertCache.java
+++ b/vidarr-prometheus/src/main/java/ca/on/oicr/gsi/vidarr/prometheus/AlertCache.java
@@ -1,9 +1,10 @@
 package ca.on.oicr.gsi.vidarr.prometheus;
 
+import static ca.on.oicr.gsi.vidarr.prometheus.AlertmanagerAutoInhibitConsumableResource.MAPPER;
+
 import ca.on.oicr.gsi.cache.ReplacingRecord;
 import ca.on.oicr.gsi.cache.ValueCache;
 import ca.on.oicr.gsi.vidarr.JsonBodyHandler;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -11,22 +12,15 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.stream.Stream;
 
-public class AlertCache extends ValueCache<Stream<AlertDto>> {
+public final class AlertCache extends ValueCache<Stream<AlertDto>> {
   private static final HttpClient HTTP_CLIENT = HttpClient.newHttpClient();
   private final String alertmanagerUrl;
-  private final ObjectMapper MAPPER;
   private final Integer requestTimeout;
 
-  public AlertCache(
-      String name,
-      String alertManagerUrl,
-      Integer requestTimeout,
-      Integer ttl,
-      ObjectMapper mapper) {
+  public AlertCache(String name, String alertManagerUrl, Integer requestTimeout, Integer ttl) {
     super("alertmanager " + name, ttl, ReplacingRecord::new);
     this.alertmanagerUrl = alertManagerUrl;
     this.requestTimeout = requestTimeout;
-    this.MAPPER = mapper;
   }
 
   protected Stream<AlertDto> fetch(Instant lastUpdated) throws Exception {

--- a/vidarr-prometheus/src/main/java/ca/on/oicr/gsi/vidarr/prometheus/AlertmanagerAutoInhibitConsumableResource.java
+++ b/vidarr-prometheus/src/main/java/ca/on/oicr/gsi/vidarr/prometheus/AlertmanagerAutoInhibitConsumableResource.java
@@ -24,7 +24,7 @@ import java.util.stream.Stream;
  * name, workflow name & version (as workflowName_version), or a fixed set of global inhibit values.
  */
 public class AlertmanagerAutoInhibitConsumableResource implements ConsumableResource {
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+  static final ObjectMapper MAPPER = new ObjectMapper();
   private static final ObjectReader READER = MAPPER.readerFor(new TypeReference<List<String>>() {});
 
   public static ConsumableResourceProvider provider() {
@@ -101,7 +101,7 @@ public class AlertmanagerAutoInhibitConsumableResource implements ConsumableReso
           "The consumableResources 'alertmanager-auto-inhibit' config is missing "
               + "'valuesOfInterest': [string].");
     }
-    cache = new AlertCache(name, alertmanagerUrl, cacheRequestTimeout, cacheTtl, MAPPER);
+    cache = new AlertCache(name, alertmanagerUrl, cacheRequestTimeout, cacheTtl);
   }
 
   @Override


### PR DESCRIPTION
Avoid copying a constant field into the alert cache.

- [NA ] Includes a change file
- [NA] Updates developer documentation

