### PR TITLE
Provide more information to consumable resources

### DIFF
--- a/changes/add_cr_extra.md
+++ b/changes/add_cr_extra.md
@@ -1,0 +1,1 @@
+* Provide more information to consumable resources (the database workflow run creation time and max-in-flight-per-workflow)

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/ManualOverrideConsumableResource.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/ManualOverrideConsumableResource.java
@@ -14,7 +14,9 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.util.Headers;
 import io.undertow.util.PathTemplateMatch;
 import io.undertow.util.StatusCodes;
+import java.time.Instant;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.BiPredicate;
@@ -77,10 +79,16 @@ public final class ManualOverrideConsumableResource implements ConsumableResourc
 
   @Override
   public ConsumableResourceResponse request(
-      String workflowName, String workflowVersion, String vidarrId, Optional<JsonNode> input) {
+      String workflowName,
+      String workflowVersion,
+      String vidarrId,
+      Instant createdTime,
+      OptionalInt workflowMaxInFlight,
+      Optional<JsonNode> input) {
     return allowList.contains(vidarrId)
         ? ConsumableResourceResponse.AVAILABLE
-        : inner.request(workflowName, workflowVersion, vidarrId, input);
+        : inner.request(
+            workflowName, workflowVersion, vidarrId, createdTime, OptionalInt.empty(), input);
   }
 
   public void setInner(ConsumableResource inner) {

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/MaxInFlightConsumableResource.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/MaxInFlightConsumableResource.java
@@ -7,7 +7,9 @@ import ca.on.oicr.gsi.vidarr.ConsumableResourceProvider;
 import ca.on.oicr.gsi.vidarr.ConsumableResourceResponse;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.JsonNode;
+import java.time.Instant;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
@@ -33,18 +35,28 @@ public final class MaxInFlightConsumableResource implements ConsumableResource {
   }
 
   @Override
-  public void recover(String workflowName, String workflowVersion, String vidarrId, Optional<JsonNode> resourceJson) {
+  public void recover(
+      String workflowName,
+      String workflowVersion,
+      String vidarrId,
+      Optional<JsonNode> resourceJson) {
     inFlight.add(vidarrId);
   }
 
   @Override
-  public void release(String workflowName, String workflowVersion, String vidarrId, Optional<JsonNode> input) {
+  public void release(
+      String workflowName, String workflowVersion, String vidarrId, Optional<JsonNode> input) {
     inFlight.remove(vidarrId);
   }
 
   @Override
   public synchronized ConsumableResourceResponse request(
-      String workflowName, String workflowVersion, String vidarrId, Optional<JsonNode> input) {
+      String workflowName,
+      String workflowVersion,
+      String vidarrId,
+      Instant createdTime,
+      OptionalInt workflowMaxInFlight,
+      Optional<JsonNode> input) {
     if (inFlight.size() <= maximum) {
       inFlight.add(vidarrId);
       return ConsumableResourceResponse.AVAILABLE;

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/ConsumableResource.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/ConsumableResource.java
@@ -11,9 +11,11 @@ import com.fasterxml.jackson.databind.annotation.JsonTypeIdResolver;
 import com.fasterxml.jackson.databind.jsontype.impl.TypeIdResolverBase;
 import io.undertow.server.HttpHandler;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.ServiceLoader;
 import java.util.ServiceLoader.Provider;
 import java.util.stream.Collectors;
@@ -121,12 +123,20 @@ public interface ConsumableResource {
    * @param workflowName the name of the workflow
    * @param workflowVersion the version of the workflow
    * @param vidarrId the identifier of the workflow run
+   * @param createdTime the time the workflow run was created
+   * @param workflowMaxInFlight this is the max-in-flight value stored in the database for this
+   *     workflow
    * @param input the consumable resource information requested from the submitter, if applicable
    *     and provided.
    * @return whether this resource is available
    */
   ConsumableResourceResponse request(
-      String workflowName, String workflowVersion, String vidarrId, Optional<JsonNode> input);
+      String workflowName,
+      String workflowVersion,
+      String vidarrId,
+      Instant createdTime,
+      OptionalInt workflowMaxInFlight,
+      Optional<JsonNode> input);
 
   /**
    * Called to initialise this consumable resource.

--- a/vidarr-prometheus/src/main/java/ca/on/oicr/gsi/vidarr/prometheus/AlertmanagerAutoInhibitConsumableResource.java
+++ b/vidarr-prometheus/src/main/java/ca/on/oicr/gsi/vidarr/prometheus/AlertmanagerAutoInhibitConsumableResource.java
@@ -10,8 +10,10 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -110,18 +112,28 @@ public class AlertmanagerAutoInhibitConsumableResource implements ConsumableReso
   }
 
   @Override
-  public void recover(String workflowName, String workflowVersion, String vidarrId, Optional<JsonNode> resourceJson) {
+  public void recover(
+      String workflowName,
+      String workflowVersion,
+      String vidarrId,
+      Optional<JsonNode> resourceJson) {
     // Do nothing, as there's no intermediate state that needs to be tracked
   }
 
   @Override
-  public void release(String workflowName, String workflowVersion, String vidarrId, Optional<JsonNode> input) {
+  public void release(
+      String workflowName, String workflowVersion, String vidarrId, Optional<JsonNode> input) {
     // Do nothing, as this doesn't actually hold onto any resources
   }
 
   @Override
   public ConsumableResourceResponse request(
-      String workflowName, String workflowVersion, String vidarrId, Optional<JsonNode> input) {
+      String workflowName,
+      String workflowVersion,
+      String vidarrId,
+      Instant createdTime,
+      OptionalInt workflowMaxInFlight,
+      Optional<JsonNode> input) {
     String workflowVersionWithUnderscores = workflowVersion.replaceAll("\\.", "_");
     final var matchedAlertValues =
         cache

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Candidate.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Candidate.java
@@ -1,0 +1,5 @@
+package ca.on.oicr.gsi.vidarr.server;
+
+import java.time.Instant;
+
+record Candidate(long id, String workflowRun, Instant created) {}

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
@@ -2222,7 +2222,7 @@ public final class Main implements ServerConfig {
 
   private void recover() throws SQLException {
     final var recoveredWorkflows = new ArrayList<Runnable>();
-    processor.recover(recoveredWorkflows::add);
+    processor.recover(recoveredWorkflows::add, this.maxInFlightPerWorkflow);
     if (recoveredWorkflows.isEmpty()) {
       System.err.println("No unstarted workflows in the database. Resuming normal operation.");
     } else {
@@ -2262,6 +2262,7 @@ public final class Main implements ServerConfig {
             body.getExternalKeys(),
             body.getConsumableResources(),
             body.getAttempt(),
+            this.maxInFlightPerWorkflow,
             new DatabaseBackedProcessor.SubmissionResultHandler<
                 Pair<Integer, SubmitWorkflowResponse>>() {
               @Override

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/MaxInFlightByWorkflow.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/MaxInFlightByWorkflow.java
@@ -7,8 +7,10 @@ import ca.on.oicr.gsi.vidarr.ConsumableResourceResponse;
 import ca.on.oicr.gsi.vidarr.api.InFlightCountsByWorkflow;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.prometheus.client.Gauge;
+import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -42,13 +44,28 @@ final class MaxInFlightByWorkflow implements ConsumableResource {
     return counts;
   }
 
+  public OptionalInt getMaximumFor(String workflow) {
+    return Optional.of(workflows.get(workflow))
+        .map(state -> OptionalInt.of(state.maximum))
+        .orElse(OptionalInt.empty());
+  }
+
   @Override
   public Optional<Pair<String, BasicType>> inputFromSubmitter() {
     return Optional.empty();
   }
 
   @Override
-  public void recover(String workflowName, String workflowVersion, String vidarrId, Optional<JsonNode> resourceJson) {
+  public boolean isInputFromSubmitterRequired() {
+    return false;
+  }
+
+  @Override
+  public void recover(
+      String workflowName,
+      String workflowVersion,
+      String vidarrId,
+      Optional<JsonNode> resourceJson) {
     final var stateRunning = workflows.computeIfAbsent(workflowName, k -> new MaxState()).running;
     // since we just created it if it doesn't exist, no need for null check here
     stateRunning.add(vidarrId);
@@ -56,7 +73,8 @@ final class MaxInFlightByWorkflow implements ConsumableResource {
   }
 
   @Override
-  public void release(String workflowName, String workflowVersion, String vidarrId, Optional<JsonNode> input) {
+  public void release(
+      String workflowName, String workflowVersion, String vidarrId, Optional<JsonNode> input) {
     final var state = workflows.get(workflowName);
     if (state != null) {
       state.running.remove(vidarrId);
@@ -66,7 +84,12 @@ final class MaxInFlightByWorkflow implements ConsumableResource {
 
   @Override
   public synchronized ConsumableResourceResponse request(
-      String workflowName, String workflowVersion, String vidarrId, Optional<JsonNode> input) {
+      String workflowName,
+      String workflowVersion,
+      String vidarrId,
+      Instant createdTime,
+      OptionalInt workflowMaxInFlight,
+      Optional<JsonNode> input) {
     final var state = workflows.get(workflowName);
     if (state == null) {
       return ConsumableResourceResponse.error(
@@ -84,18 +107,13 @@ final class MaxInFlightByWorkflow implements ConsumableResource {
     }
   }
 
-  @Override
-  public void startup(String name) {
-    // Always ok.
-  }
-
   public void set(String workflowName, int maxInFlight) {
     maxInFlightCount.labels(workflowName).set(maxInFlight);
     workflows.computeIfAbsent(workflowName, k -> new MaxState()).maximum = maxInFlight;
   }
 
   @Override
-  public boolean isInputFromSubmitterRequired() {
-    return false;
+  public void startup(String name) {
+    // Always ok.
   }
 }

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/PriorityByWorkflow.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/PriorityByWorkflow.java
@@ -9,23 +9,24 @@ import ca.on.oicr.gsi.vidarr.ConsumableResourceProvider;
 import ca.on.oicr.gsi.vidarr.ConsumableResourceResponse;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.prometheus.client.Gauge;
+import java.time.Instant;
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.SortedSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-
 public final class PriorityByWorkflow implements ConsumableResource {
 
-  //1 is lowest priority
-  //4 is highest priority (will be given access to resources first)
+  // 1 is lowest priority
+  // 4 is highest priority (will be given access to resources first)
   private final List<Integer> acceptedPriorities = Arrays.asList(1, 2, 3, 4);
 
   public static ConsumableResourceProvider provider() {
@@ -34,42 +35,47 @@ public final class PriorityByWorkflow implements ConsumableResource {
 
   private static final class WaitingState {
 
-    private final SortedSet<SimpleEntry<String, Integer>> waiting = new ConcurrentSkipListSet<SimpleEntry<String, Integer>>(comparingByValue()){
+    private final SortedSet<SimpleEntry<String, Integer>> waiting =
+        new ConcurrentSkipListSet<SimpleEntry<String, Integer>>(comparingByValue()) {
 
-      //Replace if key matches, even if entire pair doesn't
-      @Override
-      public boolean add(SimpleEntry<String, Integer> simpleEntry) {
-        SimpleEntry<String, Integer> entry = this.getByKey(simpleEntry.getKey());
-        if(entry != null){super.remove(entry);}
-        return super.add(simpleEntry);
-      }
-
-      public SimpleEntry<String, Integer> getByKey(String simpleEntryKey){
-        for (SimpleEntry<String, Integer> entry : this){
-          if (entry.getKey().equals(simpleEntryKey)) {return(entry);}
-        }
-        return null;
-      }
-
-      //Override to remove by key instead of pair
-      @Override
-      public boolean remove(Object o) {
-        try {
-          String oEntry = (String) o;
-          for (SimpleEntry<String, Integer> entry : this){
-            if (entry.getKey().equals(oEntry)) {super.remove(entry);}
+          // Replace if key matches, even if entire pair doesn't
+          @Override
+          public boolean add(SimpleEntry<String, Integer> simpleEntry) {
+            SimpleEntry<String, Integer> entry = this.getByKey(simpleEntry.getKey());
+            if (entry != null) {
+              super.remove(entry);
+            }
+            return super.add(simpleEntry);
           }
-        } catch (Exception e){
-          return false;
-        }
-        return true;
-      }
 
-    };
+          public SimpleEntry<String, Integer> getByKey(String simpleEntryKey) {
+            for (SimpleEntry<String, Integer> entry : this) {
+              if (entry.getKey().equals(simpleEntryKey)) {
+                return (entry);
+              }
+            }
+            return null;
+          }
+
+          // Override to remove by key instead of pair
+          @Override
+          public boolean remove(Object o) {
+            try {
+              String oEntry = (String) o;
+              for (SimpleEntry<String, Integer> entry : this) {
+                if (entry.getKey().equals(oEntry)) {
+                  super.remove(entry);
+                }
+              }
+            } catch (Exception e) {
+              return false;
+            }
+            return true;
+          }
+        };
   }
 
-
-  //not currently monitored by anything - potentially remove?
+  // not currently monitored by anything - potentially remove?
   private static final Gauge currentInPriorityWaitingCount =
       Gauge.build(
               "vidarr_in_priority_waiting_per_workflow_current",
@@ -85,14 +91,19 @@ public final class PriorityByWorkflow implements ConsumableResource {
   }
 
   @Override
-  public void recover(String workflowName, String workflowVersion, String vidarrId, Optional<JsonNode> resourceJson) {
+  public void recover(
+      String workflowName,
+      String workflowVersion,
+      String vidarrId,
+      Optional<JsonNode> resourceJson) {
     // Do nothing, as once the workflow run launches, it is no longer tracked in PriorityByWorkflow
   }
 
   @Override
-  public void release(String workflowName, String workflowVersion, String vidarrId, Optional<JsonNode> input) {
-    //If workflow run did not launch, re-add to waiting list
-    if (input.isPresent()){
+  public void release(
+      String workflowName, String workflowVersion, String vidarrId, Optional<JsonNode> input) {
+    // If workflow run did not launch, re-add to waiting list
+    if (input.isPresent()) {
       set(workflowName, vidarrId, input);
     }
     // Otherwise do nothing
@@ -100,20 +111,27 @@ public final class PriorityByWorkflow implements ConsumableResource {
 
   @Override
   public synchronized ConsumableResourceResponse request(
-      String workflowName, String workflowVersion, String vidarrId, Optional<JsonNode> input) {
+      String workflowName,
+      String workflowVersion,
+      String vidarrId,
+      Instant created,
+      OptionalInt workflowMaxInFlight,
+      Optional<JsonNode> input) {
 
     int workflowPriority = Collections.min(acceptedPriorities);
     if (input.isPresent()) {
       workflowPriority = input.get().asInt();
     }
 
-    if (!acceptedPriorities.contains(workflowPriority)){
+    if (!acceptedPriorities.contains(workflowPriority)) {
       return ConsumableResourceResponse.error(
-          String.format("Vidarr error: The workflow '%s' run's priority (%d) is invalid. Priority "
-              + "values should be one of the following: %s", workflowName, workflowPriority,
+          String.format(
+              "Vidarr error: The workflow '%s' run's priority (%d) is invalid. Priority "
+                  + "values should be one of the following: %s",
+              workflowName,
+              workflowPriority,
               acceptedPriorities.stream().map(String::valueOf).collect(Collectors.joining(", "))));
     }
-
 
     final var state = workflows.get(workflowName);
     if (state == null || state.waiting.isEmpty()) {
@@ -122,7 +140,8 @@ public final class PriorityByWorkflow implements ConsumableResource {
 
     // If this workflow has already been seen
     // Add the current run to the waitlist
-    // ensuring it replaces previous runs with the same ID, accounting for if the priority has changed
+    // ensuring it replaces previous runs with the same ID, accounting for if the priority has
+    // changed
     set(workflowName, vidarrId, input);
 
     if (workflowPriority >= state.waiting.last().getValue()) {
@@ -132,11 +151,9 @@ public final class PriorityByWorkflow implements ConsumableResource {
     } else {
       currentInPriorityWaitingCount.labels(workflowName).set(state.waiting.size());
       return ConsumableResourceResponse.error(
-          String.format("There are %s workflows currently queued up with higher priority.",
-              workflowName));
+          String.format(
+              "There are %s workflows currently queued up with higher priority.", workflowName));
     }
-
-
   }
 
   public void set(String workflowName, String vidarrId, Optional<JsonNode> input) {
@@ -146,10 +163,10 @@ public final class PriorityByWorkflow implements ConsumableResource {
       workflowPriority = input.get().asInt();
     }
 
-    final var stateWaiting = workflows.computeIfAbsent(workflowName, k -> new WaitingState()).waiting;
+    final var stateWaiting =
+        workflows.computeIfAbsent(workflowName, k -> new WaitingState()).waiting;
     stateWaiting.add(new SimpleEntry<String, Integer>(vidarrId, workflowPriority));
     currentInPriorityWaitingCount.labels(workflowName).set(stateWaiting.size());
-
   }
 
   @Override
@@ -162,4 +179,3 @@ public final class PriorityByWorkflow implements ConsumableResource {
     return false;
   }
 }
-

--- a/vidarr-server/src/test/java/ca/on/oicr/gsi/vidarr/server/PriorityByWorkflowTest.java
+++ b/vidarr-server/src/test/java/ca/on/oicr/gsi/vidarr/server/PriorityByWorkflowTest.java
@@ -7,7 +7,9 @@ import ca.on.oicr.gsi.vidarr.ConsumableResourceResponse;
 import ca.on.oicr.gsi.vidarr.ConsumableResourceResponse.Visitor;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
 import java.util.Optional;
+import java.util.OptionalInt;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -52,7 +54,13 @@ public class PriorityByWorkflowTest {
     JsonNode invalidJson = mapper.valueToTree(5);
 
     Optional<String> requestError =
-        sut.request(workflow, version, "abcdef", Optional.of(invalidJson))
+        sut.request(
+                workflow,
+                version,
+                "abcdef",
+                Instant.EPOCH,
+                OptionalInt.empty(),
+                Optional.of(invalidJson))
             .apply(consumableResourceCheckerVisitor);
     assertTrue(requestError.isPresent());
     assertEquals(
@@ -64,7 +72,8 @@ public class PriorityByWorkflowTest {
   @Test
   public void testRequest_emptyInputAndEmptyWaitingNoError() {
     Optional<String> requestError =
-        sut.request(workflow, version, "abcdef", Optional.empty())
+        sut.request(
+                workflow, version, "abcdef", Instant.EPOCH, OptionalInt.empty(), Optional.empty())
             .apply(consumableResourceCheckerVisitor);
 
     assertTrue(requestError.isEmpty());
@@ -73,7 +82,9 @@ public class PriorityByWorkflowTest {
   @Test
   public void testRequest_emptyInputAndEmptyWaitingIsAvailable() {
 
-    var response = sut.request(workflow, version, "abcdef", Optional.empty());
+    var response =
+        sut.request(
+            workflow, version, "abcdef", Instant.EPOCH, OptionalInt.empty(), Optional.empty());
 
     assertEquals(response, ConsumableResourceResponse.AVAILABLE);
   }
@@ -82,7 +93,13 @@ public class PriorityByWorkflowTest {
   public void testRequest_validInputAndEmptyWaitingIsOk() {
     JsonNode validJson = mapper.valueToTree(2);
     Optional<String> requestError =
-        sut.request(workflow, version, "abcdef", Optional.of(validJson))
+        sut.request(
+                workflow,
+                version,
+                "abcdef",
+                Instant.EPOCH,
+                OptionalInt.empty(),
+                Optional.of(validJson))
             .apply(consumableResourceCheckerVisitor);
 
     assertTrue(requestError.isEmpty());
@@ -96,7 +113,13 @@ public class PriorityByWorkflowTest {
     sut.set(workflow, "qwerty", Optional.of(higherPriority));
 
     Optional<String> requestError =
-        sut.request(workflow, version, "abcdef", Optional.of(lowerPriority))
+        sut.request(
+                workflow,
+                version,
+                "abcdef",
+                Instant.EPOCH,
+                OptionalInt.empty(),
+                Optional.of(lowerPriority))
             .apply(consumableResourceCheckerVisitor);
 
     assertTrue(requestError.isPresent());
@@ -113,7 +136,13 @@ public class PriorityByWorkflowTest {
     sut.set(workflow, "qwerty", Optional.of(lowerPriority));
 
     Optional<String> requestError =
-        sut.request(workflow, version, "abcdef", Optional.of(higherPriority))
+        sut.request(
+                workflow,
+                version,
+                "abcdef",
+                Instant.EPOCH,
+                OptionalInt.empty(),
+                Optional.of(higherPriority))
             .apply(consumableResourceCheckerVisitor);
 
     assertTrue(requestError.isEmpty());
@@ -126,7 +155,14 @@ public class PriorityByWorkflowTest {
 
     sut.set(workflow, "qwerty", Optional.of(lowerPriority));
 
-    var response = sut.request(workflow, version, "abcdef", Optional.of(higherPriority));
+    var response =
+        sut.request(
+            workflow,
+            version,
+            "abcdef",
+            Instant.EPOCH,
+            OptionalInt.empty(),
+            Optional.of(higherPriority));
 
     assertEquals(response, ConsumableResourceResponse.AVAILABLE);
   }
@@ -139,7 +175,13 @@ public class PriorityByWorkflowTest {
     sut.set(workflow, "qwerty", Optional.of(twoPriority));
 
     Optional<String> requestError =
-        sut.request(workflow, version, "abcdef", Optional.of(twoPriorityAlso))
+        sut.request(
+                workflow,
+                version,
+                "abcdef",
+                Instant.EPOCH,
+                OptionalInt.empty(),
+                Optional.of(twoPriorityAlso))
             .apply(consumableResourceCheckerVisitor);
 
     assertTrue(requestError.isEmpty());
@@ -152,7 +194,14 @@ public class PriorityByWorkflowTest {
 
     sut.set(workflow, "qwerty", Optional.of(twoPriority));
 
-    var response = sut.request(workflow, version, "abcdef", Optional.of(twoPriorityAlso));
+    var response =
+        sut.request(
+            workflow,
+            version,
+            "abcdef",
+            Instant.EPOCH,
+            OptionalInt.empty(),
+            Optional.of(twoPriorityAlso));
 
     assertEquals(response, ConsumableResourceResponse.AVAILABLE);
   }
@@ -162,11 +211,18 @@ public class PriorityByWorkflowTest {
     JsonNode lowestPriority = mapper.valueToTree(1);
 
     Optional<String> requestErrorForEmpty =
-        sut.request(workflow, version, "abcdef", Optional.empty())
+        sut.request(
+                workflow, version, "abcdef", Instant.EPOCH, OptionalInt.empty(), Optional.empty())
             .apply(consumableResourceCheckerVisitor);
 
     Optional<String> requestErrorForLowest =
-        sut.request(workflow, version, "abcdef", Optional.of(lowestPriority))
+        sut.request(
+                workflow,
+                version,
+                "abcdef",
+                Instant.EPOCH,
+                OptionalInt.empty(),
+                Optional.of(lowestPriority))
             .apply(consumableResourceCheckerVisitor);
 
     assertTrue(requestErrorForEmpty.isEmpty());
@@ -180,13 +236,25 @@ public class PriorityByWorkflowTest {
     JsonNode lowerPriority = mapper.valueToTree(1);
 
     Optional<String> requestErrorHigher =
-        sut.request(workflow, version, "qwerty", Optional.of(higherPriority))
+        sut.request(
+                workflow,
+                version,
+                "qwerty",
+                Instant.EPOCH,
+                OptionalInt.empty(),
+                Optional.of(higherPriority))
             .apply(consumableResourceCheckerVisitor);
 
     sut.release(workflow, version, "qwerty", Optional.of(higherPriority));
 
     Optional<String> requestErrorLower =
-        sut.request(workflow, version, "abcdef", Optional.of(lowerPriority))
+        sut.request(
+                workflow,
+                version,
+                "abcdef",
+                Instant.EPOCH,
+                OptionalInt.empty(),
+                Optional.of(lowerPriority))
             .apply(consumableResourceCheckerVisitor);
 
     assertTrue(requestErrorHigher.isEmpty());
@@ -203,13 +271,25 @@ public class PriorityByWorkflowTest {
     JsonNode lowerPriority = mapper.valueToTree(1);
 
     Optional<String> requestErrorHigher =
-        sut.request(workflow, version, "qwerty", Optional.of(higherPriority))
+        sut.request(
+                workflow,
+                version,
+                "qwerty",
+                Instant.EPOCH,
+                OptionalInt.empty(),
+                Optional.of(higherPriority))
             .apply(consumableResourceCheckerVisitor);
 
     sut.release(workflow, version, "qwerty", Optional.empty());
 
     Optional<String> requestErrorLower =
-        sut.request(workflow, version, "abcdef", Optional.of(lowerPriority))
+        sut.request(
+                workflow,
+                version,
+                "abcdef",
+                Instant.EPOCH,
+                OptionalInt.empty(),
+                Optional.of(lowerPriority))
             .apply(consumableResourceCheckerVisitor);
 
     assertTrue(requestErrorHigher.isEmpty());
@@ -221,11 +301,18 @@ public class PriorityByWorkflowTest {
 
     JsonNode validJson = mapper.valueToTree(2);
 
-    sut.request(workflow, version, "qwerty", Optional.of(validJson))
+    sut.request(
+            workflow, version, "qwerty", Instant.EPOCH, OptionalInt.empty(), Optional.of(validJson))
         .apply(consumableResourceCheckerVisitor);
 
     Optional<String> requestError =
-        sut.request(workflow, version, "abcdef", Optional.of(validJson))
+        sut.request(
+                workflow,
+                version,
+                "abcdef",
+                Instant.EPOCH,
+                OptionalInt.empty(),
+                Optional.of(validJson))
             .apply(consumableResourceCheckerVisitor);
 
     assertTrue(requestError.isEmpty());
@@ -240,7 +327,13 @@ public class PriorityByWorkflowTest {
     sut.set(workflow, "qwerty", Optional.of(higherPriority));
 
     Optional<String> requestErrorLower =
-        sut.request(workflow, version, "qwerty", Optional.of(lowerPriority))
+        sut.request(
+                workflow,
+                version,
+                "qwerty",
+                Instant.EPOCH,
+                OptionalInt.empty(),
+                Optional.of(lowerPriority))
             .apply(consumableResourceCheckerVisitor);
 
     assertTrue(requestErrorLower.isEmpty());


### PR DESCRIPTION
Plumbs the database workflow run creation time and max-in-flight-per-workflow to the consumable resource API.

Jira ticket:

- [X] Includes a change file
- [X] Updates developer documentation

