### PR TITLE
[GP-4227] fix input provisioning recovery

### DIFF
--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/JsonPath.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/JsonPath.java
@@ -24,7 +24,7 @@ public abstract class JsonPath {
     @Override
     public JsonPath deserialize(
         JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
-      return switch (jsonParser.nextValue()) {
+      return switch (jsonParser.currentToken()) {
         case VALUE_NUMBER_INT -> array(jsonParser.getIntValue());
         case VALUE_STRING -> object(jsonParser.getText());
         default -> throw new IllegalArgumentException("Invalid path operation");


### PR DESCRIPTION
Jira ticket: GP-4227

Deserializer was advancing the parser when jackson is supposed to handle that - this leads to skipping ahead to tokens our deserializer doesn't need to worry about, and getting exceptions when parsing unexpected tokens or beyond the end of the string.

- [n/a] Includes a change file
- [n/a] Updates developer documentation

