### PR TITLE
Clarify unintuitive behaviour around vidarr workflow run hash generation

### DIFF
--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
@@ -287,6 +287,8 @@ public abstract class DatabaseBackedProcessor
         digest.update(label.getBytes(StandardCharsets.UTF_8));
         digest.update(new byte[] {0});
         digest.update(MAPPER.writeValueAsBytes(labelsFromClient.get(label)));
+	// Note that if the .get(label) value is a string, writeValueAsBytes will also encode the literal (escaped) quote marks around the value.
+	// This means that if you are generating a workflow run hash outside of vidarr, if your label value is a string then you need to surround it with literal (escaped) quotes when hashing
       }
 
       return hexDigits(digest.digest());


### PR DESCRIPTION
Jira ticket: N/A

- [ ] Includes a change file
- [ ] Updates developer documentation

Mei ran into this issue when trying to generate a workflow run hash ID for the `import_bam` workflow, and I found that this behaviour was unintuitive enough that I wanted to document it. 

A question for reviewers: what do you think about extending the comment with:

> "So if you are generating a workflow run hash outside of vidarr (for a `/load` operation), if your label value is a string then you need to surround it with literal (escaped) quotes when hashing (in other words you want to pass `\"value\"` to your hashing function)"

Too wordy/obvious? 