### PR TITLE
Do not ignore instanceName

### DIFF
--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/ProvenanceWorkflowRun.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/ProvenanceWorkflowRun.java
@@ -59,7 +59,6 @@ public final class ProvenanceWorkflowRun<K extends ExternalId> {
     return inputFiles;
   }
 
-  @JsonIgnore
   public String getInstanceName() {
     return instanceName;
   }


### PR DESCRIPTION
Jira ticket: GP-4616

This should allow Shesmu to actually read the instanceName instead of just setting it to null

- [x] Includes a change file
- [ ] Updates developer documentation

