### PR TITLE
Always advance to CLEANUP phase when recovering all-succeeded P4

### DIFF
--- a/changes/fix_provision-out-recovery.md
+++ b/changes/fix_provision-out-recovery.md
@@ -1,0 +1,1 @@
+Always advance to CLEANUP phase when recovering PROVISION-OUT


### PR DESCRIPTION
Previous logic was setting the workflow to completed and then not advancing to the CLEANUP phase, leaving the workflow SUCCEEDED in phase four but QUEUED to finish processing indefinitely. Always move on to the final phase of processing.

Jira ticket:

- [X] Includes a change file
- [ ] Updates developer documentation

