### PR TITLE
Rename interface methods

### DIFF
--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseProcessor.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseProcessor.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.lang.System.Logger.Level;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -939,7 +938,7 @@ public abstract class BaseProcessor<
                     "",
                     target
                         .engine()
-                        .run()
+                        .build()
                         .map(WorkflowEngine.Result::serialize)
                         .recover(operation.recoveryState()))
                 .start(this, operation, p3.createTerminal(operation));

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseProcessor.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseProcessor.java
@@ -846,7 +846,7 @@ public abstract class BaseProcessor<
                     operation.type(),
                     target
                         .provisionerFor(WorkflowOutputDataType.valueOf(operation.type()).format())
-                        .runPreflight()
+                        .buildPreflight()
                         .recover(operation.recoveryState()))
                 .start(this, operation, p1.createTerminal(operation));
           }

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/OneOfInputProvisioner.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/OneOfInputProvisioner.java
@@ -60,7 +60,7 @@ public final class OneOfInputProvisioner implements InputProvisioner<BranchState
   }
 
   @Override
-  public BranchState provision(WorkflowLanguage language, String id, String path) {
+  public BranchState prepareInternalProvisionInput(WorkflowLanguage language, String id, String path) {
     return provision(provisioners.get(internal), language, id, path);
   }
 
@@ -69,11 +69,11 @@ public final class OneOfInputProvisioner implements InputProvisioner<BranchState
       WorkflowLanguage language,
       String id,
       String path) {
-    return provisioner.run().intoBranch(internal, provisioner.provision(language, id, path));
+    return provisioner.build().intoBranch(internal, provisioner.prepareInternalProvisionInput(language, id, path));
   }
 
   @Override
-  public BranchState provisionExternal(WorkflowLanguage language, JsonNode metadata) {
+  public BranchState prepareExternalProvisionInput(WorkflowLanguage language, JsonNode metadata) {
     final var type = metadata.get("type").asText();
     return provisionExternal(type, provisioners.get(type), language, metadata.get("contents"));
   }
@@ -83,14 +83,14 @@ public final class OneOfInputProvisioner implements InputProvisioner<BranchState
       InputProvisioner<OriginalState> provisioner,
       WorkflowLanguage language,
       JsonNode metadata) {
-    return provisioner.run().intoBranch(name, provisioner.provisionExternal(language, metadata));
+    return provisioner.build().intoBranch(name, provisioner.prepareExternalProvisionInput(language, metadata));
   }
 
   @Override
-  public OperationAction<?, BranchState, JsonNode> run() {
+  public OperationAction<?, BranchState, JsonNode> build() {
     return OperationAction.branch(
         provisioners.entrySet().stream()
-            .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().run())));
+            .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().build())));
   }
 
   public void setInternal(String internal) {

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/OneOfOutputProvisioner.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/OneOfOutputProvisioner.java
@@ -49,11 +49,11 @@ public final class OneOfOutputProvisioner implements OutputProvisioner<BranchSta
 
   private <PreflightState extends Record> BranchState preflightCheck(
       String type, OutputProvisioner<PreflightState, ?> provisioner, JsonNode metadata) {
-    return provisioner.runPreflight().intoBranch(type, provisioner.preflightCheck(metadata));
+    return provisioner.buildPreflight().intoBranch(type, provisioner.preflightCheck(metadata));
   }
 
   @Override
-  public BranchState provision(String workflowRunId, String data, JsonNode metadata) {
+  public BranchState prepareProvisionInput(String workflowRunId, String data, JsonNode metadata) {
     final var type = metadata.get("type").asText();
     return provision(type, provisioners.get(type), workflowRunId, data, metadata.get("contents"));
   }
@@ -64,21 +64,21 @@ public final class OneOfOutputProvisioner implements OutputProvisioner<BranchSta
       String workflowRunId,
       String data,
       JsonNode metadata) {
-    return provisioner.run().intoBranch(type, provisioner.provision(workflowRunId, data, metadata));
+    return provisioner.build().intoBranch(type, provisioner.prepareProvisionInput(workflowRunId, data, metadata));
   }
 
   @Override
-  public OperationAction<?, BranchState, Result> run() {
+  public OperationAction<?, BranchState, Result> build() {
     return OperationAction.branch(
         provisioners.entrySet().stream()
-            .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().run())));
+            .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().build())));
   }
 
   @Override
-  public OperationAction<?, BranchState, Boolean> runPreflight() {
+  public OperationAction<?, BranchState, Boolean> buildPreflight() {
     return OperationAction.branch(
         provisioners.entrySet().stream()
-            .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().runPreflight())));
+            .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().buildPreflight())));
   }
 
   @Override

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/PrepareInputProvisioning.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/PrepareInputProvisioning.java
@@ -32,7 +32,7 @@ final class PrepareInputProvisioning implements InputType.Visitor<JsonNode> {
       String filePath) {
     return TaskStarter.of(
         "i" + format.name(),
-        wrapProvisionActionInternal(language, provisioner, provisioner.run())
+        wrapProvisionActionInternal(language, provisioner, provisioner.build())
             .launch(new InputProvisioningStateInternal(mutation, id, filePath)));
   }
 
@@ -44,7 +44,7 @@ final class PrepareInputProvisioning implements InputType.Visitor<JsonNode> {
       JsonNode metadata) {
     return TaskStarter.of(
         "e" + format.name(),
-        wrapProvisionActionExternal(language, provisioner, provisioner.run())
+        wrapProvisionActionExternal(language, provisioner, provisioner.build())
             .launch(new InputProvisioningStateExternal(mutation, metadata)));
   }
 
@@ -56,12 +56,12 @@ final class PrepareInputProvisioning implements InputType.Visitor<JsonNode> {
       case 'i':
         return TaskStarter.of(
             operation.type(),
-            wrapProvisionActionInternal(language, provisioner, provisioner.run())
+            wrapProvisionActionInternal(language, provisioner, provisioner.build())
                 .recover(operation.recoveryState()));
       case 'e':
         return TaskStarter.of(
             operation.type(),
-            wrapProvisionActionExternal(language, provisioner, provisioner.run())
+            wrapProvisionActionExternal(language, provisioner, provisioner.build())
                 .recover(operation.recoveryState()));
       default:
         throw new IllegalArgumentException("Illegal type for operation: " + operation.type());
@@ -81,7 +81,7 @@ final class PrepareInputProvisioning implements InputType.Visitor<JsonNode> {
             InputProvisioningStateExternal.class, InputProvisioningStateExternal::metadata)
         .then(
             OperationStatefulStep.subStep(
-                (state, metadata) -> provisioner.provisionExternal(language, metadata), action))
+                (state, metadata) -> provisioner.prepareExternalProvisionInput(language, metadata), action))
         .map((state, result) -> new JsonMutation(state.state().mutation(), result));
   }
 
@@ -98,7 +98,7 @@ final class PrepareInputProvisioning implements InputType.Visitor<JsonNode> {
             InputProvisioningStateInternal.class, InputProvisioningStateInternal::id)
         .then(
             OperationStatefulStep.subStep(
-                (state, id) -> provisioner.provision(language, id, state.path()), action))
+                (state, id) -> provisioner.prepareInternalProvisionInput(language, id, state.path()), action))
         .map((state, result) -> new JsonMutation(state.state().mutation(), result));
   }
 

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/RawInputProvisioner.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/RawInputProvisioner.java
@@ -44,17 +44,17 @@ public final class RawInputProvisioner implements InputProvisioner<RawInputState
   }
 
   @Override
-  public RawInputState provision(WorkflowLanguage language, String id, String path) {
+  public RawInputState prepareInternalProvisionInput(WorkflowLanguage language, String id, String path) {
     return new RawInputState(JsonNodeFactory.instance.textNode(path));
   }
 
   @Override
-  public RawInputState provisionExternal(WorkflowLanguage language, JsonNode metadata) {
+  public RawInputState prepareExternalProvisionInput(WorkflowLanguage language, JsonNode metadata) {
     return new RawInputState(metadata);
   }
 
   @Override
-  public OperationAction<?, RawInputState, JsonNode> run() {
+  public OperationAction<?, RawInputState, JsonNode> build() {
     return OperationAction.load(RawInputState.class, RawInputState::path)
         .then(OperationStep.require(JsonNode::isTextual, "Input is not text"));
   }

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/TaskStarter.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/TaskStarter.java
@@ -49,7 +49,7 @@ interface TaskStarter<Output> {
 
     return of(
         format.name(),
-        wrapOutputProvisioner(provisioner, provisioner.run())
+        wrapOutputProvisioner(provisioner, provisioner.build())
             .launch(new OutputProvisionState(ids, labels, workflowRunId, data, metadata)));
   }
 
@@ -79,7 +79,7 @@ interface TaskStarter<Output> {
       OutputProvisioner<PreflightState, ?> provisioner,
       JsonNode metadata) {
     return of(
-        format.name(), provisioner.runPreflight().launch(provisioner.preflightCheck(metadata)));
+        format.name(), provisioner.buildPreflight().launch(provisioner.preflightCheck(metadata)));
   }
 
   static <Cleanup extends Record> TaskStarter<Void> launchCleanup(
@@ -140,7 +140,7 @@ interface TaskStarter<Output> {
 
   static <OriginalState extends Record> OperationAction<?, ?, ProvisionData> wrapOutputProvisioner(
       OutputProvisioner<?, OriginalState> provisioner) {
-    return wrapOutputProvisioner(provisioner, provisioner.run());
+    return wrapOutputProvisioner(provisioner, provisioner.build());
   }
 
   private static <State extends Record, OriginalState extends Record>
@@ -151,7 +151,7 @@ interface TaskStarter<Output> {
     return OperationAction.load(OutputProvisionState.class, OutputProvisionState::workflowRunId)
         .then(
             OperationStatefulStep.subStep(
-                (state, id) -> provisioner.provision(id, state.data(), state.metadata()), action))
+                (state, id) -> provisioner.prepareProvisionInput(id, state.data(), state.metadata()), action))
         .map(
             (state, result) ->
                 new ProvisionData(state.state().ids(), state.state().labels(), result));

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/TaskStarter.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/TaskStarter.java
@@ -62,10 +62,10 @@ interface TaskStarter<Output> {
     return of(
         "",
         engine
-            .run()
+            .build()
             .map(WorkflowEngine.Result::serialize)
             .launch(
-                engine.start(
+                engine.prepareInput(
                     definition.language(),
                     definition.contents(),
                     definition.accessoryFiles(),

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/TaskStarter.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/TaskStarter.java
@@ -34,7 +34,7 @@ interface TaskStarter<Output> {
       String workflowRunUrl) {
     return of(
         "$" + provisioner.name(),
-        wrapRuntimeAction(provisioner, provisioner.run())
+        wrapRuntimeAction(provisioner, provisioner.build())
             .launch(new RuntimeProvisionState(ids, labels, workflowRunUrl)));
   }
 
@@ -163,7 +163,7 @@ interface TaskStarter<Output> {
               RuntimeProvisioner<OriginalState> provisioner,
               OperationAction<State, OriginalState, OutputProvisioner.Result> action) {
     return OperationAction.load(RuntimeProvisionState.class, RuntimeProvisionState::workflowRunUrl)
-        .then(OperationStatefulStep.subStep((state, url) -> provisioner.provision(url), action))
+        .then(OperationStatefulStep.subStep((state, url) -> provisioner.prepareProvisionInput(url), action))
         .map(
             (state, result) ->
                 new ProvisionData(state.state().ids(), state.state().labels(), result));
@@ -172,7 +172,7 @@ interface TaskStarter<Output> {
   static <OriginalState extends Record>
       OperationAction<?, RuntimeProvisionState, ProvisionData> wrapRuntimeProvisioner(
           RuntimeProvisioner<OriginalState> provisioner) {
-    return wrapRuntimeAction(provisioner, provisioner.run());
+    return wrapRuntimeAction(provisioner, provisioner.build());
   }
 
   String name();

--- a/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/CromwellOutputProvisioner.java
+++ b/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/CromwellOutputProvisioner.java
@@ -189,12 +189,12 @@ public class CromwellOutputProvisioner
   }
 
   @Override
-  public ProvisionState provision(String workflowRunId, String data, JsonNode metadata) {
+  public ProvisionState prepareProvisionInput(String workflowRunId, String data, JsonNode metadata) {
     return new ProvisionState(cromwellUrl, data, metadata, workflowRunId);
   }
 
   @Override
-  public OperationAction<?, ProvisionState, OutputProvisioner.Result> run() {
+  public OperationAction<?, ProvisionState, OutputProvisioner.Result> build() {
     return load(ProvisionState.class, (state) -> state.buildLaunchRequest(this))
         .then(http(new JsonBodyHandler<>(MAPPER, WorkflowStatusResponse.class)))
         .then(
@@ -239,7 +239,7 @@ public class CromwellOutputProvisioner
   }
 
   @Override
-  public OperationAction<?, PreflightState, Boolean> runPreflight() {
+  public OperationAction<?, PreflightState, Boolean> buildPreflight() {
     return OperationAction.value(PreflightState.class, true);
   }
 

--- a/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/CromwellWorkflowEngine.java
+++ b/vidarr-cromwell/src/main/java/ca/on/oicr/gsi/vidarr/cromwell/CromwellWorkflowEngine.java
@@ -109,7 +109,7 @@ public final class CromwellWorkflowEngine implements WorkflowEngine<StateUnstart
   }
 
   @Override
-  public OperationAction<?, StateUnstarted, Result<CleanupState>> run() {
+  public OperationAction<?, StateUnstarted, Result<CleanupState>> build() {
     return load(StateUnstarted.class, StateUnstarted::buildLaunchRequest)
         .then(http(new JsonBodyHandler<>(MAPPER, WorkflowStatusResponse.class)))
         .then(
@@ -174,7 +174,7 @@ public final class CromwellWorkflowEngine implements WorkflowEngine<StateUnstart
   }
 
   @Override
-  public StateUnstarted start(
+  public StateUnstarted prepareInput(
       WorkflowLanguage workflowLanguage,
       String workflow,
       Stream<Pair<String, String>> accessoryFiles,

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/InputProvisioner.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/InputProvisioner.java
@@ -73,36 +73,42 @@ public interface InputProvisioner<State extends Record> {
   BasicType externalTypeFor(InputProvisionFormat format);
 
   /**
-   * Begin provisioning out a new input that was registered in Vidarr
+   * Prepare state to provision in data that was registered in Vidarr
    *
    * <p>This method should not do any externally-visible work. Anything it needs should be done in a
-   * {@link #run()} so that Vidarr can execute it once the database is in a healthy state.
+   * {@link #build()} so that Vidarr can execute it once the database is in a healthy state.
+   * If build() is compared to Pattern.compile(), then prepareExternalProvisionInput prepares the String
+   * that will have match() executed against it.
    *
    * @param language the workflow language the output will be consumed by
    * @param id the Vidarr ID for the file
    * @param path the output path registered in Vidarr for the file
-   * @return the initial state of the provision out process
+   * @return the initial state of the provision in process
    */
-  State provision(WorkflowLanguage language, String id, String path);
+  State prepareInternalProvisionInput(WorkflowLanguage language, String id, String path);
 
   /**
-   * Begin provisioning out a new input that was not registered in Vidarr
+   * Prepare state to provision in data that was not registered in Vidarr
    *
    * <p>This method should not do any externally-visible work. Anything it needs should be done in a
-   * {@link #run()} so that Vidarr can execute it once the database is in a healthy state.
+   * {@link #build()} so that Vidarr can execute it once the database is in a healthy state.
+   * If build() is compared to Pattern.compile(), then prepareExternalProvisionInput prepares the String
+   * that will have match() executed against it.
    *
    * @param language the workflow language the output will be consumed by
    * @param metadata the information coming from the submitter to direct provisioning
-   * @return the initial state of the provision out process
+   * @return the initial state of the provision in process
    */
-  State provisionExternal(WorkflowLanguage language, JsonNode metadata);
+  State prepareExternalProvisionInput(WorkflowLanguage language, JsonNode metadata);
 
   /**
-   * Create a declarative structure to execute the provisioning
+   * Build a declarative structure to execute the provisioning when played back
    *
+   * Compare to Pattern.compile() - builds a ready object for later use by the processor.
+   * This allows the processor to play back and pause the sequence of events built here.
    * @return the sequence of operations that should be performed
    */
-  OperationAction<?, State, JsonNode> run();
+  OperationAction<?, State, JsonNode> build();
   /**
    * Called to initialise this input provisioner.
    *

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/OutputProvisioner.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/OutputProvisioner.java
@@ -156,28 +156,33 @@ public interface OutputProvisioner<PreflightState extends Record, State extends 
    * Prepare state to provision out data
    *
    * <p>This method should not do any externally-visible work. Anything it needs should be done in a
-   * {@link #run()} so that Vidarr can execute it once the database is in a healthy state.
+   * {@link #build()} so that Vidarr can execute it once the database is in a healthy state.
+   * If build() is compared to Pattern.compile(), then prepareProvisionInput prepares the String that will
+   * have match() executed against it.
    *
    * @param workflowRunId the workflow run ID assigned by Vidarr
    * @param data the output coming from the workflow
    * @param metadata the information coming from the submitter to direct provisioning
    * @return the initial state of the provision out process
    */
-  State provision(String workflowRunId, String data, JsonNode metadata);
+  State prepareProvisionInput(String workflowRunId, String data, JsonNode metadata);
 
   /**
-   * Create a declarative structure to execute the provisioning
+   * Build a declarative structure to execute the provisioning when played back
+   *
+   * Compare to Pattern.compile() - builds a ready object for later use by the processor.
+   * This allows the processor to play back and pause the sequence of events built here.
    *
    * @return the sequence of operations that should be performed
    */
-  OperationAction<?, State, Result> run();
+  OperationAction<?, State, Result> build();
 
   /**
-   * Create a declarative structure to execute the pre-flight check
+   * Build a declarative structure to execute the pre-flight check when played back
    *
    * @return the sequence of operations that should be performed
    */
-  OperationAction<?, PreflightState, Boolean> runPreflight();
+  OperationAction<?, PreflightState, Boolean> buildPreflight();
 
   /**
    * Called to initialise this output provisioner.

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/RuntimeProvisioner.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/RuntimeProvisioner.java
@@ -79,21 +79,27 @@ public interface RuntimeProvisioner<State extends Record> {
   String name();
 
   /**
-   * Create state for provisioning the output
+   * Prepare state to provision out data
    *
-   * <p>This method should do not work. It should only create state for use by the {@link #run()}
+   * <p>This method should not do any externally-visible work. Anything it needs should be done in a
+   * {@link #build()} so that Vidarr can execute it once the database is in a healthy state.
+   * If build() is compared to Pattern.compile(), then prepareProvisionInput prepares the String
+   * that will have match() executed against it.
    *
    * @param workflowRunUrl the URL provided by the {@link WorkflowEngine.Result#workflowRunUrl()}
-   * @return the state that will be used by {@link #run()}
+   * @return the state that will be used by {@link #build()}
    */
-  State provision(String workflowRunUrl);
+  State prepareProvisionInput(String workflowRunUrl);
 
   /**
-   * Create a declarative structure to execute the provisioning
+   * Build a declarative structure to execute the provisioning when played back
+   *
+   * Compare to Pattern.compile() - builds a ready object for later use by the processor.
+   * This allows the processor to play back and pause the sequence of events built here.
    *
    * @return the sequence of operations that should be performed
    */
-  OperationAction<?, State, OutputProvisioner.Result> run();
+  OperationAction<?, State, OutputProvisioner.Result> build();
 
   /**
    * Called to initialise this runtime provisioner.

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/WorkflowEngine.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/WorkflowEngine.java
@@ -107,17 +107,22 @@ public interface WorkflowEngine<State extends Record, CleanupState extends Recor
   Optional<BasicType> engineParameters();
 
   /**
-   * Create a declarative structure to execute a workflow
+   * Build a declarative structure which executes a workflow when played back
+   *
+   * Compare to Pattern.compile() - builds a ready object for later use by the processor.
+   * This allows the processor to play back and pause the sequence of events built here.
    *
    * @return the sequence of operations that should be performed
    */
-  OperationAction<?, State, Result<CleanupState>> run();
+  OperationAction<?, State, Result<CleanupState>> build();
 
   /**
-   * Start a new workflow
+   * Prepare the input to a new workflow
    *
    * <p>This method should not do any externally-visible work. It should simply populate the state
-   * structure that will be used by {@link #run()}.
+   * structure that will be used by the object created in {@link #build()}.
+   * If build() is compared to Pattern.compile(), then prepareInput prepares the String that will
+   * have match() executed against it.
    *
    * @param workflowLanguage the language the workflow was written in
    * @param workflow the contents of the workflow
@@ -127,7 +132,7 @@ public interface WorkflowEngine<State extends Record, CleanupState extends Recor
    * @param engineParameters the input configuration parameters to the workflow engine
    * @return the initial state of the provision out process
    */
-  State start(
+  State prepareInput(
       WorkflowLanguage workflowLanguage,
       String workflow,
       Stream<Pair<String, String>> accessoryFiles,

--- a/vidarr-sh/src/main/java/ca/on/oicr/gsi/vidarr/sh/UnixShellWorkflowEngine.java
+++ b/vidarr-sh/src/main/java/ca/on/oicr/gsi/vidarr/sh/UnixShellWorkflowEngine.java
@@ -46,7 +46,7 @@ public final class UnixShellWorkflowEngine implements WorkflowEngine<StateInitia
   }
 
   @Override
-  public OperationAction<?, StateInitial, Result<CleanupState>> run() {
+  public OperationAction<?, StateInitial, Result<CleanupState>> build() {
     return OperationAction.load(
             StateInitial.class,
             state ->
@@ -66,7 +66,7 @@ public final class UnixShellWorkflowEngine implements WorkflowEngine<StateInitia
   }
 
   @Override
-  public StateInitial start(
+  public StateInitial prepareInput(
       WorkflowLanguage workflowLanguage,
       String workflow,
       Stream<Pair<String, String>> accessoryFiles,


### PR DESCRIPTION
Rename methods in WorkflowEngine and all the different Provisioners to better explain what they do. Open to feedback about the documentation and naming.

Jira ticket:

- [ ] Includes a change file
- [ ] Updates developer documentation

