### PR TITLE
Fix recover provision out where only some operations are SUCCEEDED

### DIFF
--- a/changes/fix_recover_po.md
+++ b/changes/fix_recover_po.md
@@ -1,0 +1,1 @@
+Bug in where workflow runs would hang at provision out with all operations SUCCEEDED when the workflow run was recovered and only some operations were SUCCEEDED and others were FAILED/PLUGIN_RUNNING

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseProcessor.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseProcessor.java
@@ -966,7 +966,8 @@ public abstract class BaseProcessor<
         } else {
           for (final var operation : activeOperations) {
             if (operation.status().equals(OperationStatus.SUCCEEDED)) {
-              // only launch the non-succeeded operations
+              // update the count of outstanding operations
+              p4.size.decrementAndGet();
               continue;
             }
             if (operation.type().startsWith("$")) {


### PR DESCRIPTION
Jira ticket: GP-4639

- [x] Includes a change file
- [ ] Updates developer documentation

Going straight to `continue` meant the processor had an inaccurate count of how many operations were still outstanding when it was doing this check: https://github.com/oicr-gsi/vidarr/blob/master/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseProcessor.java#L637