### PR TITLE
Fix recovery issue in provision in (and preflight as well)

### DIFF
--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseProcessor.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/BaseProcessor.java
@@ -842,6 +842,11 @@ public abstract class BaseProcessor<
           p1.release(true);
         } else {
           for (final var operation : activeOperations) {
+            if (operation.status().equals(OperationStatus.SUCCEEDED)) {
+              // update the count of outstanding operations
+              p1.outstanding.decrementAndGet();
+              continue;
+            }
             TaskStarter.of(
                     operation.type(),
                     target
@@ -863,6 +868,11 @@ public abstract class BaseProcessor<
           );
         } else {
           for (final var operation : activeOperations) {
+            if (operation.status().equals(OperationStatus.SUCCEEDED)) {
+              // update the count of outstanding operations
+              p2.size.decrementAndGet();
+              continue;
+            }
             PrepareInputProvisioning.recover(
                     definition.language(),
                     operation,


### PR DESCRIPTION
Jira ticket: GP-4717
- [x] Includes a change file
- [ ] Updates developer documentation

Only recover the non-succeeded operations. Provision in (and preflight as well) tracks how many operations are succeeded, so we need to update that count.