### PR TITLE
Fix vidarr-cache fetch initial cache population exception

### DIFF
--- a/changes/fix_vidar-cardea_cache_fetch.md
+++ b/changes/fix_vidar-cardea_cache_fetch.md
@@ -1,0 +1,1 @@
+Fix vidarr-cache fetch initial cache population exception by returning the default priority

--- a/vidarr-cardea/src/main/java/ca/on/oicr/gsi/vidarr/cardea/CardeaCasePriorityInput.java
+++ b/vidarr-cardea/src/main/java/ca/on/oicr/gsi/vidarr/cardea/CardeaCasePriorityInput.java
@@ -109,8 +109,7 @@ public class CardeaCasePriorityInput implements PriorityInput {
             if (response.statusCode() == 404) {
               System.err.printf("%s: caseId=\"%s\" not found at %s\n", Level.WARNING, caseId, baseUrl);
               CARDEA_CASE_ID_UNKNOWN.labels(baseUrl).inc();
-              // compute() will determine what priority should be returned
-              return Optional.empty();
+              return Optional.of(defaultPriority);
             }
             return response.body().get();
           }


### PR DESCRIPTION
Some case ids will never have a priority returned, so we should return the default priority.

Jira ticket: https://jira.oicr.on.ca/browse/GP-4261

- [x] Includes a change file
- [ ] Updates developer documentation

