### PR TITLE
[GP-4334, GP-4163] No-Op Workflow Engine

### DIFF
--- a/built-ins.md
+++ b/built-ins.md
@@ -38,7 +38,7 @@ type.
 This provision will only handle an output format if all the provisioners can
 handle that format.
 
-## Raw Input Provider
+## Raw Input Provisioner
 The raw input provisioner assumes that output files are available as input
 files and passes them through unchanged to workflows.
 
@@ -61,3 +61,11 @@ Only file output types are supported. The provisioner will preserve the original
 outputs.
 This Output Provisioner is meant primarily for testing and development, and is not meant for use
 in production or to move large (>~2GB) files.
+
+## No-Op Workflow Engine
+This Workflow Engine is primarily used during development. Like the Raw Input Provisioner, the
+No-Op Workflow Engine passes inputs unchanged through to Output Provisioning.
+The No-Op Workflow Engine "supports" all workflow languages, because it completely ignores the 
+workflow provided.
+
+    "type": "no-op"

--- a/changes/add_noop.md
+++ b/changes/add_noop.md
@@ -1,0 +1,2 @@
+No-Op Workflow Engine for testing and reprovisioning
+

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/NoOpWorkflowEngine.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/NoOpWorkflowEngine.java
@@ -1,0 +1,72 @@
+package ca.on.oicr.gsi.vidarr.core;
+
+import static ca.on.oicr.gsi.vidarr.OperationAction.load;
+import static ca.on.oicr.gsi.vidarr.OperationAction.value;
+
+import ca.on.oicr.gsi.Pair;
+import ca.on.oicr.gsi.status.SectionRenderer;
+import ca.on.oicr.gsi.vidarr.BasicType;
+import ca.on.oicr.gsi.vidarr.OperationAction;
+import ca.on.oicr.gsi.vidarr.WorkflowEngine;
+import ca.on.oicr.gsi.vidarr.WorkflowEngineProvider;
+import ca.on.oicr.gsi.vidarr.WorkflowLanguage;
+import ca.on.oicr.gsi.vidarr.core.NoOpWorkflowEngine.CleanupState;
+import ca.on.oicr.gsi.vidarr.core.NoOpWorkflowEngine.NoOpState;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Optional;
+import java.util.stream.Stream;
+import javax.xml.stream.XMLStreamException;
+
+public class NoOpWorkflowEngine implements WorkflowEngine<NoOpState, CleanupState> {
+
+  public record NoOpState(ObjectNode params){
+    // Take the inputs and send them as the outputs
+    public Result<CleanupState> pipe(){
+      return new Result<>(params, null, Optional.empty());
+    }
+  }
+  public record CleanupState(){}
+
+  public static WorkflowEngineProvider provider() {
+    return () -> Stream.of(new Pair<>("no-op", NoOpWorkflowEngine.class));
+  }
+
+  @Override
+  public OperationAction<?, CleanupState, Void> cleanup() {
+    return value(CleanupState.class, null);
+  }
+
+  @Override
+  public void configuration(SectionRenderer sectionRenderer) throws XMLStreamException {
+    sectionRenderer.line("No-Op", "does nothing");
+  }
+
+  @Override
+  public Optional<BasicType> engineParameters() {
+    return Optional.empty();
+  }
+
+  @Override
+  public OperationAction<?, NoOpState, Result<CleanupState>> build() {
+    return load(NoOpState.class, NoOpState::pipe);
+  }
+
+  @Override
+  public NoOpState prepareInput(WorkflowLanguage workflowLanguage, String workflow,
+      Stream<Pair<String, String>> accessoryFiles, String vidarrId, ObjectNode workflowParameters,
+      JsonNode engineParameters) {
+    return new NoOpState(workflowParameters);
+  }
+
+  @Override
+  public void startup() {
+
+  }
+
+  @Override
+  public boolean supports(WorkflowLanguage language) {
+    // Who cares what language it is, we're not going to run it
+    return true;
+  }
+}

--- a/vidarr-core/src/main/java/module-info.java
+++ b/vidarr-core/src/main/java/module-info.java
@@ -4,10 +4,12 @@ import ca.on.oicr.gsi.vidarr.OutputProvisionerProvider;
 import ca.on.oicr.gsi.vidarr.PriorityFormulaProvider;
 import ca.on.oicr.gsi.vidarr.PriorityInputProvider;
 import ca.on.oicr.gsi.vidarr.PriorityScorerProvider;
+import ca.on.oicr.gsi.vidarr.WorkflowEngineProvider;
 import ca.on.oicr.gsi.vidarr.core.CoreConsumableResourceProvider;
 import ca.on.oicr.gsi.vidarr.core.CorePriorityFormulaProvider;
 import ca.on.oicr.gsi.vidarr.core.CorePriorityInputProvider;
 import ca.on.oicr.gsi.vidarr.core.CorePriorityScorerProvider;
+import ca.on.oicr.gsi.vidarr.core.NoOpWorkflowEngine;
 import ca.on.oicr.gsi.vidarr.core.LocalOutputProvisioner;
 import ca.on.oicr.gsi.vidarr.core.OneOfInputProvisioner;
 import ca.on.oicr.gsi.vidarr.core.OneOfOutputProvisioner;
@@ -47,4 +49,6 @@ module ca.on.oicr.gsi.vidarr.core {
       CorePriorityFormulaProvider;
   provides PriorityScorerProvider with
       CorePriorityScorerProvider;
+  provides WorkflowEngineProvider with
+      NoOpWorkflowEngine;
 }


### PR DESCRIPTION
Takes the inputs to a workflow and pipes them directly to the OutputProvisioner without changing anything.
For use in testing and in Reprovisioning.

Jira ticket: GP-4334, GP-4163

- [X] Includes a change file
- [X] Updates developer documentation

