### PR TITLE
Provide the workflow max in flight to the overrideable inner resource

### DIFF
--- a/changes/fix_override.md
+++ b/changes/fix_override.md
@@ -1,0 +1,1 @@
+Fixes bug in manually overriding priority consumable resource

--- a/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/ManualOverrideConsumableResource.java
+++ b/vidarr-core/src/main/java/ca/on/oicr/gsi/vidarr/core/ManualOverrideConsumableResource.java
@@ -85,7 +85,7 @@ public final class ManualOverrideConsumableResource implements ConsumableResourc
     return allowList.contains(vidarrId)
         ? ConsumableResourceResponse.AVAILABLE
         : inner.request(
-            workflowName, workflowVersion, vidarrId, createdTime, OptionalInt.empty(), input);
+            workflowName, workflowVersion, vidarrId, createdTime, workflowMaxInFlight, input);
   }
 
   public void setInner(ConsumableResource inner) {


### PR DESCRIPTION
Our config specifies the default max in flight for a workflow is 0, and this oversight was causing the inner in-flight scorer to always use the default max in flight 