### PR TITLE
Add lastAccessed field to ProvenanceWorkflowRun

### DIFF
--- a/changes/add_lastAccessed_field.md
+++ b/changes/add_lastAccessed_field.md
@@ -1,0 +1,1 @@
+`lastAccessed` field to `ProvenanceWorkflowRun` API class

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/ProvenanceWorkflowRun.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/ProvenanceWorkflowRun.java
@@ -21,6 +21,7 @@ public final class ProvenanceWorkflowRun<K extends ExternalId> {
   private List<String> inputFiles;
   private String instanceName;
   private ObjectNode labels;
+  private ZonedDateTime lastAccessed;
   private ObjectNode metadata;
   private ZonedDateTime modified;
   private ZonedDateTime started;
@@ -65,6 +66,10 @@ public final class ProvenanceWorkflowRun<K extends ExternalId> {
 
   public ObjectNode getLabels() {
     return labels;
+  }
+
+  public ZonedDateTime getLastAccessed() {
+    return lastAccessed;
   }
 
   public ObjectNode getMetadata() {
@@ -129,6 +134,10 @@ public final class ProvenanceWorkflowRun<K extends ExternalId> {
 
   public void setLabels(ObjectNode labels) {
     this.labels = labels;
+  }
+
+  public void setLastAccessed(ZonedDateTime lastAccessed) {
+    this.lastAccessed = lastAccessed;
   }
 
   public void setMetadata(ObjectNode metadata) {


### PR DESCRIPTION
This will allow Shesmu to make use of the field

Jira ticket:

- [x] Includes a change file
- [ ] Updates developer documentation (or n/a)

Note that this field is [already getting populated](https://github.com/oicr-gsi/vidarr/blob/master/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java#L1053) in the method that serves the provenance endpoint.