### PR TITLE
Only include latest external id versions by version key in unload file

### DIFF
--- a/changes/change_version_policy_for_unload.md
+++ b/changes/change_version_policy_for_unload.md
@@ -1,0 +1,1 @@
+unload requests now serve only the latest (by `requested` timestamp) version for each key for each external ID

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadedData.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadedData.java
@@ -6,11 +6,11 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class UnloadedData {
 
-  private List<ProvenanceWorkflowRun<ExternalMultiVersionKey>> workflowRuns;
+  private List<ProvenanceWorkflowRun<ExternalKey>> workflowRuns;
   private List<UnloadedWorkflowVersion> workflowVersions;
   private List<UnloadedWorkflow> workflows;
 
-  public List<ProvenanceWorkflowRun<ExternalMultiVersionKey>> getWorkflowRuns() {
+  public List<ProvenanceWorkflowRun<ExternalKey>> getWorkflowRuns() {
     return workflowRuns;
   }
 
@@ -22,7 +22,7 @@ public class UnloadedData {
     return workflows;
   }
 
-  public void setWorkflowRuns(List<ProvenanceWorkflowRun<ExternalMultiVersionKey>> workflowRuns) {
+  public void setWorkflowRuns(List<ProvenanceWorkflowRun<ExternalKey>> workflowRuns) {
     this.workflowRuns = workflowRuns;
   }
 


### PR DESCRIPTION
The latest version must be equivalent to any earlier versions, so only serve the latest version in the unload file. We can always go forwards from this version, or fill in history if need be.

Jira ticket: GP-4828

- [x] Includes a change file
- [x] Updates developer documentation (or n/a)

