### PR TITLE
[GP-5046] Tweaks to importing to make life with Shesmu happier

### DIFF
--- a/changes/change_conflict.md
+++ b/changes/change_conflict.md
@@ -1,0 +1,2 @@
+SubmitWorkflowResponseConflict now returned when reprovisioning already underway, including id of job underway
+

--- a/changes/change_unverified.md
+++ b/changes/change_unverified.md
@@ -1,0 +1,1 @@
+load-injected now does not require a workflow definition to be included in the request, if a workflow version matching the name and version is found in the database, it will be filled in.

--- a/changes/fix_response.md
+++ b/changes/fix_response.md
@@ -1,0 +1,2 @@
+Response bodies now returned when importing
+

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
@@ -507,10 +507,14 @@ public final class Main implements ServerConfig {
     Semaphore s = reprovisionCounter.getOrDefault(reprovisionOutRequest.getWorkflowRunHashId(), new Semaphore(1));
     if(!s.tryAcquire()){
       exchange.setStatusCode(StatusCodes.INSUFFICIENT_STORAGE);
-      exchange
-          .getResponseSender()
-          .send(
-              "There is already a reprovision request on this workflow run right now. Please try again later.");
+      try {
+        exchange
+            .getResponseSender()
+            .send(
+                MAPPER.writeValueAsString(new SubmitWorkflowResponseConflict(List.of(reprovisionOutRequest.getWorkflowRunHashId()))));
+      } catch (JsonProcessingException e) {
+        throw new RuntimeException(e);
+      }
       return;
     }
     reprovisionCounter.put(reprovisionOutRequest.getWorkflowRunHashId(), s);

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
@@ -633,6 +633,8 @@ public final class Main implements ServerConfig {
                         .collect(Collectors.toList())));
           }
         });
+    // Clear content-length header in case it was previously set to 0
+    exchange.getResponseHeaders().remove(Headers.CONTENT_LENGTH);
     exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, CONTENT_TYPE_JSON);
     exchange.setStatusCode(response.first());
     if (postCommitAction.get() != null) {

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
@@ -12,6 +12,7 @@ import static ca.on.oicr.gsi.vidarr.server.jooq.Tables.WORKFLOW_DEFINITION;
 import static ca.on.oicr.gsi.vidarr.server.jooq.Tables.WORKFLOW_RUN;
 import static ca.on.oicr.gsi.vidarr.server.jooq.Tables.WORKFLOW_VERSION;
 import static ca.on.oicr.gsi.vidarr.server.jooq.Tables.WORKFLOW_VERSION_ACCESSORY;
+import static org.jooq.impl.DSL.jsonObject;
 import static org.jooq.impl.DSL.param;
 
 import ca.on.oicr.gsi.Pair;
@@ -1814,42 +1815,46 @@ public final class Main implements ServerConfig {
     }
   }
 
-  private JSONObjectNullStep<JSON> workflowVersionFields() {
-    return DSL.jsonObject(
-        literalJsonEntry("name", WORKFLOW_VERSION.NAME),
-        literalJsonEntry("version", WORKFLOW_VERSION.VERSION),
-        literalJsonEntry("id", WORKFLOW_VERSION.HASH_ID),
-        literalJsonEntry("metadata", WORKFLOW_VERSION.METADATA),
-        literalJsonEntry("parameters", WORKFLOW_VERSION.PARAMETERS),
-        literalJsonEntry(
-            "labels",
-            DSL.field(
-                DSL.select(WORKFLOW.LABELS)
-                    .from(WORKFLOW)
-                    .where(WORKFLOW.NAME.eq(WORKFLOW_VERSION.NAME)))),
-        literalJsonEntry("language", WORKFLOW_DEFINITION.WORKFLOW_LANGUAGE),
-        literalJsonEntry("outputs", WORKFLOW_VERSION.METADATA));
+  private JSONObjectNullStep<JSON> workflowVersionFields(boolean includeDbId) {
+    List<JSONEntry<?>> entries = new ArrayList<>();
+    entries.add(literalJsonEntry("name", WORKFLOW_VERSION.NAME));
+    entries.add(literalJsonEntry("version", WORKFLOW_VERSION.VERSION));
+    entries.add(literalJsonEntry("id", WORKFLOW_VERSION.HASH_ID));
+    entries.add(literalJsonEntry("metadata", WORKFLOW_VERSION.METADATA));
+    entries.add(literalJsonEntry("parameters", WORKFLOW_VERSION.PARAMETERS));
+    entries.add(literalJsonEntry(
+        "labels",
+        DSL.field(
+            DSL.select(WORKFLOW.LABELS)
+                .from(WORKFLOW)
+                .where(WORKFLOW.NAME.eq(WORKFLOW_VERSION.NAME)))));
+    entries.add(literalJsonEntry("language", WORKFLOW_DEFINITION.WORKFLOW_LANGUAGE));
+    entries.add(literalJsonEntry("outputs", WORKFLOW_VERSION.METADATA));
+    if (includeDbId) {
+      entries.add(literalJsonEntry("dbId", WORKFLOW_VERSION.ID));
+    }
+    return jsonObject(entries);
   }
 
-  private JSONObjectNullStep<JSON> workflowVersionWithDefinitionFields() {
+  private JSONObjectNullStep<JSON> workflowVersionWithDefinitionFields(boolean includeDbId) {
+    List<JSONEntry<?>> entries = new ArrayList<>();
     final WorkflowDefinition accessoryDefinition =
         WORKFLOW_DEFINITION.as("accessoryWorkflowDefinition");
-    return DSL.jsonObject(
-        literalJsonEntry("name", WORKFLOW_VERSION.NAME),
-        literalJsonEntry("version", WORKFLOW_VERSION.VERSION),
-        literalJsonEntry("id", WORKFLOW_VERSION.HASH_ID),
-        literalJsonEntry("metadata", WORKFLOW_VERSION.METADATA),
-        literalJsonEntry("parameters", WORKFLOW_VERSION.PARAMETERS),
-        literalJsonEntry(
+        entries.add(literalJsonEntry("name", WORKFLOW_VERSION.NAME));
+    entries.add(literalJsonEntry("version", WORKFLOW_VERSION.VERSION));
+    entries.add(literalJsonEntry("id", WORKFLOW_VERSION.HASH_ID));
+    entries.add(literalJsonEntry("metadata", WORKFLOW_VERSION.METADATA));
+    entries.add(literalJsonEntry("parameters", WORKFLOW_VERSION.PARAMETERS));
+    entries.add(literalJsonEntry(
             "labels",
             DSL.field(
                 DSL.select(WORKFLOW.LABELS)
                     .from(WORKFLOW)
-                    .where(WORKFLOW.NAME.eq(WORKFLOW_VERSION.NAME)))),
-        literalJsonEntry("language", WORKFLOW_DEFINITION.WORKFLOW_LANGUAGE),
-        literalJsonEntry("outputs", WORKFLOW_VERSION.METADATA),
-        literalJsonEntry("workflow", WORKFLOW_DEFINITION.WORKFLOW_FILE),
-        literalJsonEntry(
+                    .where(WORKFLOW.NAME.eq(WORKFLOW_VERSION.NAME)))));
+    entries.add(literalJsonEntry("language", WORKFLOW_DEFINITION.WORKFLOW_LANGUAGE));
+    entries.add(literalJsonEntry("outputs", WORKFLOW_VERSION.METADATA));
+    entries.add(literalJsonEntry("workflow", WORKFLOW_DEFINITION.WORKFLOW_FILE));
+    entries.add(literalJsonEntry(
             "accessoryFiles",
             DSL.coalesce(
                 DSL.field(
@@ -1868,16 +1873,24 @@ public final class Main implements ServerConfig {
                                     WORKFLOW_VERSION_ACCESSORY.WORKFLOW_VERSION.eq(
                                         WORKFLOW_VERSION.ID)))),
                 DSL.inline(JSON.json("{}")))));
+
+    if(includeDbId) entries.add(literalJsonEntry("dbId", WORKFLOW_VERSION.ID));
+    return DSL.jsonObject(entries);
   }
 
   private Optional<String> fetchWorkflowVersion(String name, String version, boolean includeWorkflowDefinitions)
+      throws SQLException {
+    return fetchWorkflowVersion(name, version, includeWorkflowDefinitions, false);
+  }
+
+  private Optional<String> fetchWorkflowVersion(String name, String version, boolean includeWorkflowDefinitions, boolean includeDbId)
       throws SQLException {
     final Optional<String> result;
     try (final Connection connection = dataSource.getConnection()) {
       JSONObjectNullStep<JSON> fields =
           (includeWorkflowDefinitions
-              ? workflowVersionWithDefinitionFields()
-              : workflowVersionFields());
+              ? workflowVersionWithDefinitionFields(includeDbId)
+              : workflowVersionFields(includeDbId));
       result =
           DSL
               .using(connection, SQLDialect.POSTGRES)
@@ -2472,8 +2485,8 @@ public final class Main implements ServerConfig {
         // No ID from database because it is already installed, and we want to use that version
         // because we may have incomplete information in the load request.
         else if (workflowVersionFromDb) {
-          ObjectNode installedVersion = MAPPER.readValue(fetchWorkflowVersion(workflowName, workflowVersion, true).orElseThrow(), ObjectNode.class);
-          workflowVersionIds.put(workflowVersion, installedVersion.get("id").intValue());
+          ObjectNode installedVersion = MAPPER.readValue(fetchWorkflowVersion(workflowName, workflowVersion, true, true).orElseThrow(), ObjectNode.class);
+          workflowVersionIds.put(workflowVersion, installedVersion.get("dbId").intValue());
         }
         // No ID from database because it is already installed, and we want to ensure we have
         // the same version


### PR DESCRIPTION
Jira ticket: GP-5046

- Don't require the whole workflow definition if load mode is unverified
- Actually return a response body when importing by undoing the 'content-length:0' set in load()
- Respond with a SubmitWorkflowResponseConflict when reprovisioning is already underway so Shesmu can use that id for its purposes

- [ ] Includes a change file (any changes to the Java API should be prepended with "Java API: ")
- [ ] Updates developer documentation (or n/a)

