### PR TITLE
Only update lastAccessed if no other workflow_run updates are being performed

### DIFF
--- a/changes/fix_concurrent_update_issue.md
+++ b/changes/fix_concurrent_update_issue.md
@@ -1,0 +1,1 @@
+Concurrent update issue

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
@@ -1679,8 +1679,6 @@ public abstract class DatabaseBackedProcessor
                                                     workflowRunId,
                                                     knownMatches);
 
-                                                updateLastAccessed(context.dsl(), candidateId);
-
                                                 // If this workflow is active, but failed, and the
                                                 // attempt number is higher or this is a different
                                                 // workflow version, we should restart it.
@@ -1776,6 +1774,8 @@ public abstract class DatabaseBackedProcessor
                                                             }
                                                           }));
                                                 } else {
+                                                  updateLastAccessed(
+                                                      transaction, candidates.get(0).workflowRun());
                                                   return handler.matchExisting(
                                                       candidates.get(0).workflowRun());
                                                 }


### PR DESCRIPTION
being performed

This is a mostly-theoretical change as I haven't got a good test case, but shouldn't break anything. 

The goal is to update the lastAccessed time if a workflow run is submitted and the incoming data matches an existing workflow run. In the previous version of the code, the call to updateLastAccessed could be called in the same transaction as e.g. DatabaseWorkflow.reinitialize, which also updates the lastAccessed field on the workflow run. This PR moves the updateLastAccessed call to only be executed if the incoming workflow run data matches an existing workflow run. 

Jira ticket: GP-5379 

- [x] Includes a change file (any changes to the Java API should be prepended with "Java API: ")
- [x] Updates developer documentation (or n/a)

