### PR TITLE
Add workflow label unload filter

### DIFF
--- a/changes/add-unload-label.md
+++ b/changes/add-unload-label.md
@@ -1,0 +1,1 @@
+'vidarr-workflow-label' unload filter

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/UnloadFilter.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/UnloadFilter.java
@@ -10,6 +10,7 @@ import ca.on.oicr.gsi.vidarr.api.UnloadFilterLastSubmittedAfter;
 import ca.on.oicr.gsi.vidarr.api.UnloadFilterNot;
 import ca.on.oicr.gsi.vidarr.api.UnloadFilterOr;
 import ca.on.oicr.gsi.vidarr.api.UnloadFilterWorkflowId;
+import ca.on.oicr.gsi.vidarr.api.UnloadFilterWorkflowLabel;
 import ca.on.oicr.gsi.vidarr.api.UnloadFilterWorkflowName;
 import ca.on.oicr.gsi.vidarr.api.UnloadFilterWorkflowRunId;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -119,6 +120,13 @@ public interface UnloadFilter {
     T workflowId(Stream<String> ids);
 
     /**
+     * Match any of the workflow labels provided.
+     *
+     * @param labels The workflow labels to match
+     */
+    T workflowLabel(String label, Stream<String> values);
+
+    /**
      * Match any of the workflow names provided.
      *
      * @param names the human-readable workflow names to match
@@ -146,6 +154,7 @@ public interface UnloadFilter {
                     new Pair<>("vidarr-external-provider", UnloadFilterExternalProvider.class),
                     new Pair<>("vidarr-last-submitted-after", UnloadFilterLastSubmittedAfter.class),
                     new Pair<>("vidarr-workflow-id", UnloadFilterWorkflowId.class),
+                    new Pair<>("vidarr-workflow-label", UnloadFilterWorkflowLabel.class),
                     new Pair<>("vidarr-workflow-name", UnloadFilterWorkflowName.class),
                     new Pair<>("vidarr-workflow-run-id", UnloadFilterWorkflowRunId.class)),
                 ServiceLoader.load(UnloadFilterProvider.class).stream()

--- a/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadFilterWorkflowLabel.java
+++ b/vidarr-pluginapi/src/main/java/ca/on/oicr/gsi/vidarr/api/UnloadFilterWorkflowLabel.java
@@ -1,0 +1,25 @@
+package ca.on.oicr.gsi.vidarr.api;
+
+import ca.on.oicr.gsi.vidarr.UnloadFilter;
+import ca.on.oicr.gsi.vidarr.UnloadTextSelector;
+
+public class UnloadFilterWorkflowLabel implements UnloadFilter {
+
+  private String label;
+  private UnloadTextSelector value;
+
+  @Override
+  public <T> T convert(Visitor<T> visitor) {
+    return visitor.workflowLabel(label, value.stream());
+  }
+
+  public String getLabel(){ return label; }
+
+  public void setLabel(String label) {this.label = label;}
+
+  public UnloadTextSelector getValue(){return value;}
+
+  public void setValue(UnloadTextSelector value) {
+    this.value = value;
+  }
+}

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
@@ -149,6 +149,7 @@ import org.jooq.SQLDialect;
 import org.jooq.Table;
 import org.jooq.impl.DSL;
 import org.jooq.impl.SQLDataType;
+import org.jooq.util.postgres.PostgresDSL;
 import org.postgresql.ds.PGSimpleDataSource;
 
 public final class Main implements ServerConfig {
@@ -2912,6 +2913,33 @@ public final class Main implements ServerConfig {
                                                   @Override
                                                   public Condition workflowId(Stream<String> ids) {
                                                     return match(WORKFLOW_VERSION.HASH_ID, ids);
+                                                  }
+
+                                                  @Override
+                                                  public Condition workflowLabel(
+                                                      String label, Stream<String> values) {
+
+                                                    List<String> collectedValues = values.toList();
+                                                    switch(collectedValues.size()){
+                                                      case 0:
+                                                        return DSL.condition(false);
+                                                      case 1:
+                                                        return DSL.exists(DSL.select()
+                                                            .from(WORKFLOW_RUN)
+                                                                .where(DSL.condition(
+                                                                    "jsonb_exists(labels->?, ?)",
+                                                                    label,
+                                                                    collectedValues.iterator().next()
+                                                                )));
+                                                      default:
+                                                        return DSL.exists(DSL.select()
+                                                            .from(WORKFLOW_RUN)
+                                                            .where(DSL.condition(
+                                                                "jsonb_exists_any(labels->?, ?)",
+                                                                label,
+                                                                DSL.val(collectedValues, SQLDataType.VARCHAR.getArrayType())
+                                                            )));
+                                                    }
                                                   }
 
                                                   @Override

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/Main.java
@@ -149,7 +149,6 @@ import org.jooq.SQLDialect;
 import org.jooq.Table;
 import org.jooq.impl.DSL;
 import org.jooq.impl.SQLDataType;
-import org.jooq.util.postgres.PostgresDSL;
 import org.postgresql.ds.PGSimpleDataSource;
 
 public final class Main implements ServerConfig {

--- a/vidarr-server/src/main/resources/ca/on/oicr/gsi/vidarr/server/api-docs/vidarr.json
+++ b/vidarr-server/src/main/resources/ca/on/oicr/gsi/vidarr/server/api-docs/vidarr.json
@@ -692,6 +692,7 @@
               "vidarr-external-provider",
               "vidarr-last-submitted-after",
               "vidarr-workflow-id",
+              "vidarr-workflow-label",
               "vidarr-workflow-name",
               "vidarr-workflow-run-id"
             ],
@@ -709,6 +710,7 @@
                 "vidarr-external-provider": "#/components/schemas/UnloadFilterExternalProvider",
                 "vidarr-last-submitted-after": "#/components/schemas/UnloadFilterLastSubmittedAfter",
                 "vidarr-workflow-id": "#/components/schemas/UnloadFilterWorkflowId",
+                "vidarr-workflow-label": "#/components/schemas/UnloadFilterWorkflowLabel",
                 "vidarr-workflow-name": "#/components/schemas/UnloadFilterWorkflowName",
                 "vidarr-workflow-run-id": "#/components/schemas/UnloadFilterWorkflowRunId"
               },
@@ -741,6 +743,9 @@
               },
               {
                 "$ref": "#/components/schemas/UnloadFilterWorkflowId"
+              },
+              {
+                "$ref": "#/components/schemas/UnloadFilterWorkflowLabel"
               },
               {
                 "$ref": "#/components/schemas/UnloadFilterWorkflowName"
@@ -827,6 +832,15 @@
       "UnloadFilterWorkflowId": {
         "properties": {
           "id": {
+            "$ref": "#/components/schemas/UnloadTextSelector"
+          }
+        },
+        "type": "object"
+      },
+      "UnloadFilterWorkflowLabel": {
+        "properties": {
+          "label": {"type": "string"},
+          "value": {
             "$ref": "#/components/schemas/UnloadTextSelector"
           }
         },


### PR DESCRIPTION
Jira ticket:

Primarily, I want to empower Analysis & CGI to unload data with a particular value in the `test_iteration` label themselves when they're done with a validation or development cycle.

Filter looks like: `{"type":"vidarr-workflow-label","label":"test_iteration","value":"whatever"}` or `"value":["whatever","something"]`

- [X] Includes a change file (any changes to the Java API should be prepended with "Java API: ")
- [ ] Updates developer documentation (or n/a)

