### PR TITLE
Add vidarr-workflow-label option to copy-out API docs

### DIFF
--- a/changes/fix_concat_filter_to_api_docs.md
+++ b/changes/fix_concat_filter_to_api_docs.md
@@ -1,0 +1,1 @@
+'vidarr-workflow-label' to list of possible filters in /copy-out endpoint

--- a/vidarr-server/src/main/resources/ca/on/oicr/gsi/vidarr/server/api-docs/vidarr.json
+++ b/vidarr-server/src/main/resources/ca/on/oicr/gsi/vidarr/server/api-docs/vidarr.json
@@ -1122,7 +1122,7 @@
               }
             }
           },
-          "description": "The `filter` object contains two arguments: `type` and a value. Valid `type` options are: [\"and\", \"not\", \"or\", \"vidarr-analysis-id\", \"vidarr-completed-after\", \"vidarr-external-id\", \"vidarr-external-provider\", \"vidarr-last-submitted-after\", \"vidarr-workflow-id\", \"vidarr-workflow-name\", \"vidarr-workflow-run-id\"]. The value is type-dependent; options are described in the UnloadFilterX options in the Schemas section below.\n\nFor example, unloading by workflow run ID would look like this: { \"type\": \"vidarr-workflow-run-id\", \"id\": [\"list of one or more workflow run IDs\"] } .\n\nThe \"and\", \"not\" or \"or\" filter types accept an array of filters, which enables combining filter conditions."
+          "description": "The `filter` object contains two arguments: `type` and a value. Valid `type` options are: [\"and\", \"not\", \"or\", \"vidarr-analysis-id\", \"vidarr-completed-after\", \"vidarr-external-id\", \"vidarr-external-provider\", \"vidarr-last-submitted-after\", \"vidarr-workflow-id\", \"vidarr-workflow-name\", \"vidarr-workflow-run-id\", \"vidarr-workflow-label\"]. The value is type-dependent; options are described in the UnloadFilterX options in the Schemas section below.\n\nFor example, unloading by workflow run ID would look like this: { \"type\": \"vidarr-workflow-run-id\", \"id\": [\"list of one or more workflow run IDs\"] } .\n\nThe \"and\", \"not\" or \"or\" filter types accept an array of filters, which enables combining filter conditions."
         },
         "responses": {
           "200": {


### PR DESCRIPTION
Jira ticket: none

- [x] Includes a change file (any changes to the Java API should be prepended with "Java API: ")
- [x] Updates developer documentation (or n/a)

It's already present in the unload API docs