### PR TITLE
Correct handling when cannot resolve input external IDs

### DIFF
--- a/changes/fix_uncaught_exception.md
+++ b/changes/fix_uncaught_exception.md
@@ -1,0 +1,1 @@
+Correct handling for failure to resolve input IDs

--- a/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
+++ b/vidarr-server/src/main/java/ca/on/oicr/gsi/vidarr/server/DatabaseBackedProcessor.java
@@ -533,21 +533,29 @@ public abstract class DatabaseBackedProcessor
         .definition()
         .parameters()
         .<ExternalId>flatMap(
-            p ->
-                arguments.has(p.name())
-                    ? p.type()
-                        .apply(
-                            new ExtractInputExternalIds(
-                                MAPPER,
-                                arguments.get(p.name()),
-                                id -> {
-                                  final Optional<FileMetadata> result = pathForId(id);
-                                  if (result.isEmpty()) {
-                                    unresolvedIds.add(id);
-                                  }
-                                  return result;
-                                }))
-                    : Stream.empty())
+            p -> {
+              Stream<? extends ExternalId> stream;
+              try {
+                stream =
+                    arguments.has(p.name())
+                        ? p.type()
+                            .apply(
+                                new ExtractInputExternalIds(
+                                    MAPPER,
+                                    arguments.get(p.name()),
+                                    id -> {
+                                      final Optional<FileMetadata> result = pathForId(id);
+                                      if (result.isEmpty()) {
+                                        unresolvedIds.add(id);
+                                      }
+                                      return result;
+                                    }))
+                        : Stream.empty();
+              } catch (IllegalArgumentException e) {
+                stream = Stream.empty();
+              }
+              return stream;
+            })
         .collect(
             Collectors.toCollection(
                 () ->


### PR DESCRIPTION
Jira ticket: GP-5592

- [x] Includes a change file (any changes to the Java API should be prepended with "Java API: ")
- [x] Updates developer documentation (or n/a)

Return 400 failure, not 500 internal server error