### PR TITLE
Automate PRs to update GitHub actions to newest major version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"
+    allow:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Dependabot includes a default "cooldown" period of 3 days, so updates will only be made after the new version is > 3 days old

Jira ticket: N/A

- [ ] Includes a change file (any changes to the Java API should be prepended with "Java API: ")
- [ ] Updates developer documentation (or n/a)

